### PR TITLE
Add ESLint flat config with custom TypeScript parser

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,92 @@
+import js from "@eslint/js";
+import globals from "globals";
+import tsParser from "./tools/eslint/ts-transpile-parser.js";
+
+const IGNORED_PATTERNS = [
+  "dist/**",
+  "dist-electron/**",
+  "node_modules/**",
+  "*.config.*",
+];
+
+const sharedLanguageOptions = {
+  ecmaVersion: 2022,
+  sourceType: "module",
+};
+
+const sharedRules = {
+  "no-console": [
+    "warn",
+    {
+      allow: ["warn", "error"],
+    },
+  ],
+};
+
+export default [
+  {
+    ignores: IGNORED_PATTERNS,
+  },
+  {
+    files: ["src/**/*.ts", "src/**/*.tsx"],
+    languageOptions: {
+      ...sharedLanguageOptions,
+      parser: tsParser,
+      globals: {
+        ...globals.browser,
+      },
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      ...sharedRules,
+      "no-unused-vars": "off",
+    },
+  },
+  {
+    files: ["electron/**/*.ts"],
+    languageOptions: {
+      ...sharedLanguageOptions,
+      parser: tsParser,
+      globals: {
+        ...globals.node,
+      },
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      ...sharedRules,
+      "no-unused-vars": "off",
+    },
+  },
+  {
+    files: ["**/*.js", "**/*.cjs", "**/*.mjs"],
+    ...js.configs.recommended,
+    languageOptions: {
+      ...sharedLanguageOptions,
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+      },
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      ...sharedRules,
+      "no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
+];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import WaterDistributionSystem from './components/WaterDistributionSystem';
 
 export default function App() {

--- a/src/components/WaterDistributionSystem.tsx
+++ b/src/components/WaterDistributionSystem.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Building,
   Users,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
+  <StrictMode>
     <App />
-  </React.StrictMode>
+  </StrictMode>
 );

--- a/tools/eslint/ts-transpile-parser.js
+++ b/tools/eslint/ts-transpile-parser.js
@@ -1,0 +1,64 @@
+import * as espree from "espree";
+import ts from "typescript";
+
+const DEFAULT_COMPILER_OPTIONS = {
+  jsx: ts.JsxEmit.Preserve,
+  target: ts.ScriptTarget.ES2022,
+  module: ts.ModuleKind.ESNext,
+  useDefineForClassFields: true,
+};
+
+const DEFAULT_PARSE_OPTIONS = {
+  ecmaVersion: 2022,
+  sourceType: "module",
+  ecmaFeatures: {
+    jsx: true,
+  },
+  loc: true,
+  range: true,
+  comment: true,
+  tokens: true,
+};
+
+function transpile(code, filePath) {
+  const compilerOptions = {
+    ...DEFAULT_COMPILER_OPTIONS,
+    jsx: filePath.endsWith(".tsx") ? ts.JsxEmit.Preserve : DEFAULT_COMPILER_OPTIONS.jsx,
+  };
+
+  const result = ts.transpileModule(code, {
+    compilerOptions,
+    fileName: filePath,
+    reportDiagnostics: false,
+  });
+
+  return result.outputText;
+}
+
+const parser = {
+  parse(code, options = {}) {
+    const filePath = options.filePath ?? "file.tsx";
+
+    const transpiled = transpile(code, filePath);
+
+    const parserOptions = {
+      ...DEFAULT_PARSE_OPTIONS,
+      ...options,
+      ecmaFeatures: {
+        ...DEFAULT_PARSE_OPTIONS.ecmaFeatures,
+        ...options.ecmaFeatures,
+      },
+    };
+
+    const ast = espree.parse(transpiled, parserOptions);
+    ast.sourceType = parserOptions.sourceType;
+    return ast;
+  },
+};
+
+parser.meta = {
+  name: "ts-transpile-parser",
+  version: "1.0.0",
+};
+
+export default parser;


### PR DESCRIPTION
## Summary
- add an eslint flat config that lints TypeScript/React sources and shared JS files
- implement a lightweight parser that transpiles TypeScript before handing it to espree so eslint can run without extra dependencies
- drop unused default React imports now that the lint rules detect JSX usage without the React pragma

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d450962f248325b3d46e0a55604952