### PR TITLE
feat: add validated company and partner forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,11 @@
     "better-sqlite3": "^9.6.0",
     "electron-updater": "^6.3.9",
     "lucide-react": "^0.456.0",
+    "@hookform/resolvers": "^3.9.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-hook-form": "^7.53.0",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/node": "^22.5.4",

--- a/src/components/forms/CityChipsInput.tsx
+++ b/src/components/forms/CityChipsInput.tsx
@@ -1,0 +1,123 @@
+import { useId, useMemo, useState } from 'react';
+import { X } from 'lucide-react';
+
+type CityChipsInputProps = {
+  value: string[];
+  onChange: (cities: string[]) => void;
+  suggestions: string[];
+  placeholder?: string;
+  error?: string;
+};
+
+const normalize = (value: string) => value.trim();
+
+const CityChipsInput = ({ value, onChange, suggestions, placeholder, error }: CityChipsInputProps) => {
+  const [inputValue, setInputValue] = useState('');
+  const listboxId = useId();
+
+  const filteredSuggestions = useMemo(() => {
+    if (!inputValue) {
+      return suggestions.filter(
+        (suggestion) => !value.some((city) => city.toLowerCase() === suggestion.toLowerCase())
+      );
+    }
+
+    const search = inputValue.toLowerCase();
+    return suggestions.filter((suggestion) => {
+      const matches = suggestion.toLowerCase().includes(search);
+      const alreadySelected = value.some((city) => city.toLowerCase() === suggestion.toLowerCase());
+      return matches && !alreadySelected;
+    });
+  }, [inputValue, suggestions, value]);
+
+  const handleAddCity = (city: string) => {
+    const normalized = normalize(city);
+    if (!normalized) return;
+
+    const alreadySelected = value.some((existing) => existing.toLowerCase() === normalized.toLowerCase());
+    if (alreadySelected) {
+      setInputValue('');
+      return;
+    }
+
+    onChange([...value, normalized]);
+    setInputValue('');
+  };
+
+  const handleRemoveCity = (city: string) => {
+    onChange(value.filter((existing) => existing !== city));
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter' || event.key === ',' || event.key === 'Tab') {
+      event.preventDefault();
+      handleAddCity(inputValue);
+    }
+
+    if (event.key === 'Backspace' && inputValue.length === 0 && value.length > 0) {
+      event.preventDefault();
+      onChange(value.slice(0, -1));
+    }
+  };
+
+  return (
+    <div>
+      <div
+        className={`flex min-h-[46px] flex-wrap gap-2 rounded-lg border px-3 py-2 focus-within:ring-2 focus-within:ring-green-500 ${
+          error ? 'border-red-500 focus-within:ring-red-500' : 'border-gray-300'
+        }`}
+      >
+        {value.map((city) => (
+          <span
+            key={city}
+            className="inline-flex items-center gap-1 rounded-full bg-green-100 px-3 py-1 text-sm text-green-800"
+          >
+            {city}
+            <button
+              type="button"
+              onClick={() => handleRemoveCity(city)}
+              className="rounded-full p-0.5 text-green-700 transition hover:bg-green-200"
+              aria-label={`Remover cidade ${city}`}
+            >
+              <X className="h-3 w-3" aria-hidden="true" />
+            </button>
+          </span>
+        ))}
+        <input
+          value={inputValue}
+          onChange={(event) => setInputValue(event.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={value.length === 0 ? placeholder : undefined}
+          className="flex-1 min-w-[120px] border-none p-0 text-sm outline-none focus:outline-none"
+          aria-autocomplete="list"
+          aria-controls={listboxId}
+          aria-expanded={filteredSuggestions.length > 0}
+        />
+      </div>
+      {filteredSuggestions.length > 0 && (
+        <div
+          id={listboxId}
+          role="listbox"
+          className="mt-2 max-h-40 overflow-y-auto rounded-lg border border-gray-200 bg-white shadow-lg"
+        >
+          {filteredSuggestions.map((suggestion) => (
+            <button
+              type="button"
+              key={suggestion}
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => handleAddCity(suggestion)}
+              className="flex w-full items-center justify-between px-3 py-2 text-left text-sm text-gray-700 transition hover:bg-green-50"
+              role="option"
+            >
+              <span>{suggestion}</span>
+              <span className="text-xs text-gray-400">Adicionar</span>
+            </button>
+          ))}
+        </div>
+      )}
+      {error && <p className="mt-1 text-sm text-red-600">{error}</p>}
+    </div>
+  );
+};
+
+export default CityChipsInput;

--- a/src/components/forms/CompanyForm.tsx
+++ b/src/components/forms/CompanyForm.tsx
@@ -1,0 +1,264 @@
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Loader2 } from 'lucide-react';
+import { z } from 'zod';
+
+import { STATUSES } from '../../types/entities';
+import { applyPhoneMask, isValidPhone } from '../../utils/masks';
+
+const companySchema = z.object({
+  name: z.string().min(1, 'Informe o nome da empresa.'),
+  type: z.string().min(1, 'Informe o segmento da empresa.'),
+  stores: z
+    .number({ invalid_type_error: 'Informe o número de lojas.' })
+    .min(0, 'O número de lojas deve ser maior ou igual a zero.'),
+  totalValue: z
+    .number({ invalid_type_error: 'Informe o valor total mensal.' })
+    .min(0, 'O valor total deve ser maior ou igual a zero.'),
+  status: z.enum(STATUSES, { errorMap: () => ({ message: 'Selecione um status.' }) }),
+  contactName: z.string().min(1, 'Informe o nome do responsável.'),
+  contactPhone: z
+    .string()
+    .min(1, 'Informe o telefone do responsável.')
+    .refine(isValidPhone, 'Informe um telefone válido.'),
+  contactEmail: z.string().email('Informe um e-mail válido.'),
+});
+
+export type CompanyFormValues = z.infer<typeof companySchema>;
+
+type CompanyFormProps = {
+  onSubmit: (values: CompanyFormValues) => Promise<void>;
+  onCancel: () => void;
+  initialFocusRef?: React.RefObject<HTMLInputElement>;
+};
+
+const CompanyForm = ({ onSubmit, onCancel, initialFocusRef }: CompanyFormProps) => {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm<CompanyFormValues>({
+    resolver: zodResolver(companySchema),
+    defaultValues: {
+      name: '',
+      type: '',
+      stores: 0,
+      totalValue: 0,
+      status: 'ativo',
+      contactName: '',
+      contactPhone: '',
+      contactEmail: '',
+    },
+  });
+
+  useEffect(() => {
+    return () => reset();
+  }, [reset]);
+
+  const onFormSubmit = handleSubmit(async (values) => {
+    try {
+      await onSubmit(values);
+      reset({
+        name: '',
+        type: '',
+        stores: 0,
+        totalValue: 0,
+        status: 'ativo',
+        contactName: '',
+        contactPhone: '',
+        contactEmail: '',
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Não foi possível salvar a empresa.';
+      setError('root', { type: 'manual', message });
+    }
+  });
+
+  const statusOptions = STATUSES.map((status) => ({
+    value: status,
+    label: status === 'ativo' ? 'Ativo' : 'Inativo',
+  }));
+
+  const nameRegistration = register('name');
+
+  return (
+    <form onSubmit={onFormSubmit} className="space-y-6" noValidate>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="md:col-span-2">
+          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="company-name">
+            Nome da Empresa *
+          </label>
+          <input
+            id="company-name"
+            {...nameRegistration}
+            ref={(element) => {
+              nameRegistration.ref(element);
+              if (initialFocusRef) {
+                initialFocusRef.current = element ?? null;
+              }
+            }}
+            placeholder="Ex: ANIMALE"
+            className={`w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+              errors.name ? 'border-red-500 focus:ring-red-500' : 'border-gray-300'
+            }`}
+          />
+          {errors.name && <p className="mt-1 text-sm text-red-600">{errors.name.message}</p>}
+        </div>
+
+        <div className="md:col-span-2">
+          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="company-type">
+            Tipo de Negócio *
+          </label>
+          <input
+            id="company-type"
+            {...register('type')}
+            placeholder="Ex: Moda Feminina"
+            className={`w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+              errors.type ? 'border-red-500 focus:ring-red-500' : 'border-gray-300'
+            }`}
+          />
+          {errors.type && <p className="mt-1 text-sm text-red-600">{errors.type.message}</p>}
+        </div>
+
+        <div>
+          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="company-stores">
+            Número de Lojas *
+          </label>
+          <input
+            id="company-stores"
+            type="number"
+            step={1}
+            min={0}
+            {...register('stores', { valueAsNumber: true })}
+            className={`w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+              errors.stores ? 'border-red-500 focus:ring-red-500' : 'border-gray-300'
+            }`}
+          />
+          {errors.stores && <p className="mt-1 text-sm text-red-600">{errors.stores.message}</p>}
+        </div>
+
+        <div>
+          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="company-total-value">
+            Valor Total Mensal (R$) *
+          </label>
+          <input
+            id="company-total-value"
+            type="number"
+            step="0.01"
+            min={0}
+            {...register('totalValue', { valueAsNumber: true })}
+            className={`w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+              errors.totalValue ? 'border-red-500 focus:ring-red-500' : 'border-gray-300'
+            }`}
+          />
+          {errors.totalValue && <p className="mt-1 text-sm text-red-600">{errors.totalValue.message}</p>}
+        </div>
+
+        <div>
+          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="company-status">
+            Status *
+          </label>
+          <select
+            id="company-status"
+            {...register('status')}
+            className={`w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+              errors.status ? 'border-red-500 focus:ring-red-500' : 'border-gray-300'
+            }`}
+          >
+            <option value="">Selecione</option>
+            {statusOptions.map((status) => (
+              <option key={status.value} value={status.value}>
+                {status.label}
+              </option>
+            ))}
+          </select>
+          {errors.status && <p className="mt-1 text-sm text-red-600">{errors.status.message}</p>}
+        </div>
+
+        <div>
+          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="company-contact-email">
+            Email do Responsável *
+          </label>
+          <input
+            id="company-contact-email"
+            type="email"
+            {...register('contactEmail')}
+            placeholder="nome@empresa.com.br"
+            className={`w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+              errors.contactEmail ? 'border-red-500 focus:ring-red-500' : 'border-gray-300'
+            }`}
+          />
+          {errors.contactEmail && <p className="mt-1 text-sm text-red-600">{errors.contactEmail.message}</p>}
+        </div>
+
+        <div className="md:col-span-2">
+          <h4 className="text-sm font-semibold text-gray-700">Dados do Responsável</h4>
+        </div>
+
+        <div>
+          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="company-contact-name">
+            Nome *
+          </label>
+          <input
+            id="company-contact-name"
+            {...register('contactName')}
+            placeholder="Nome do responsável"
+            className={`w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+              errors.contactName ? 'border-red-500 focus:ring-red-500' : 'border-gray-300'
+            }`}
+          />
+          {errors.contactName && <p className="mt-1 text-sm text-red-600">{errors.contactName.message}</p>}
+        </div>
+
+        <div>
+          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="company-contact-phone">
+            Telefone *
+          </label>
+          <input
+            id="company-contact-phone"
+            {...register('contactPhone', {
+              onChange: (event) => {
+                const masked = applyPhoneMask(event.target.value);
+                event.target.value = masked;
+              },
+            })}
+            placeholder="(11) 99999-0000"
+            className={`w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+              errors.contactPhone ? 'border-red-500 focus:ring-red-500' : 'border-gray-300'
+            }`}
+          />
+          {errors.contactPhone && <p className="mt-1 text-sm text-red-600">{errors.contactPhone.message}</p>}
+        </div>
+      </div>
+
+      {errors.root && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {errors.root.message}
+        </div>
+      )}
+
+      <div className="flex justify-end gap-3">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          Cancelar
+        </button>
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="inline-flex items-center gap-2 rounded-lg bg-blue-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:bg-blue-400"
+        >
+          {isSubmitting && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
+          Salvar Empresa
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default CompanyForm;

--- a/src/components/forms/PartnerForm.tsx
+++ b/src/components/forms/PartnerForm.tsx
@@ -1,0 +1,284 @@
+import { useEffect, useMemo } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Loader2 } from 'lucide-react';
+import { z } from 'zod';
+
+import { RECEIPT_STATUSES, STATUSES } from '../../types/entities';
+import { applyPhoneMask, isValidPhone } from '../../utils/masks';
+import CityChipsInput from './CityChipsInput';
+
+const partnerSchema = z.object({
+  name: z.string().min(1, 'Informe o nome do parceiro.'),
+  region: z.string().min(1, 'Informe a região de atuação.'),
+  status: z.enum(STATUSES, { errorMap: () => ({ message: 'Selecione um status.' }) }),
+  receiptsStatus: z.enum(RECEIPT_STATUSES, {
+    errorMap: () => ({ message: 'Selecione o status dos comprovantes.' }),
+  }),
+  contactName: z.string().min(1, 'Informe o nome do responsável.'),
+  contactPhone: z
+    .string()
+    .min(1, 'Informe o telefone do responsável.')
+    .refine(isValidPhone, 'Informe um telefone válido.'),
+  contactEmail: z.string().email('Informe um e-mail válido.'),
+  cities: z
+    .array(z.string().min(1, 'Cidade inválida.'))
+    .min(1, 'Adicione pelo menos uma cidade de atuação.'),
+});
+
+export type PartnerFormValues = z.infer<typeof partnerSchema>;
+
+type PartnerFormProps = {
+  onSubmit: (values: PartnerFormValues) => Promise<void>;
+  onCancel: () => void;
+  suggestions: string[];
+  initialFocusRef?: React.RefObject<HTMLInputElement>;
+};
+
+const PartnerForm = ({ onSubmit, onCancel, suggestions, initialFocusRef }: PartnerFormProps) => {
+  const {
+    control,
+    register,
+    handleSubmit,
+    reset,
+    setError,
+    formState: { errors, isSubmitting },
+  } = useForm<PartnerFormValues>({
+    resolver: zodResolver(partnerSchema),
+    defaultValues: {
+      name: '',
+      region: '',
+      status: 'ativo',
+      receiptsStatus: 'pendente',
+      contactName: '',
+      contactPhone: '',
+      contactEmail: '',
+      cities: [],
+    },
+  });
+
+  useEffect(() => () => reset(), [reset]);
+
+  const onFormSubmit = handleSubmit(async (values) => {
+    try {
+      await onSubmit(values);
+      reset({
+        name: '',
+        region: '',
+        status: 'ativo',
+        receiptsStatus: 'pendente',
+        contactName: '',
+        contactPhone: '',
+        contactEmail: '',
+        cities: [],
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Não foi possível salvar o parceiro.';
+      setError('root', { type: 'manual', message });
+    }
+  });
+
+  const statusOptions = useMemo(
+    () =>
+      STATUSES.map((status) => ({
+        value: status,
+        label: status === 'ativo' ? 'Ativo' : 'Inativo',
+      })),
+    []
+  );
+
+  const receiptStatusOptions = useMemo(
+    () =>
+      RECEIPT_STATUSES.map((status) => ({
+        value: status,
+        label: status === 'enviado' ? 'Enviado' : 'Pendente',
+      })),
+    []
+  );
+
+  const nameRegistration = register('name');
+
+  return (
+    <form onSubmit={onFormSubmit} className="space-y-6" noValidate>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="md:col-span-2">
+          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="partner-name">
+            Nome do Parceiro *
+          </label>
+          <input
+            id="partner-name"
+            {...nameRegistration}
+            ref={(element) => {
+              nameRegistration.ref(element);
+              if (initialFocusRef) {
+                initialFocusRef.current = element ?? null;
+              }
+            }}
+            placeholder="Ex: Águas do Sul Ltda"
+            className={`w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500 ${
+              errors.name ? 'border-red-500 focus:ring-red-500' : 'border-gray-300'
+            }`}
+          />
+          {errors.name && <p className="mt-1 text-sm text-red-600">{errors.name.message}</p>}
+        </div>
+
+        <div>
+          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="partner-region">
+            Região de Atuação *
+          </label>
+          <input
+            id="partner-region"
+            {...register('region')}
+            placeholder="Ex: Sudeste"
+            className={`w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500 ${
+              errors.region ? 'border-red-500 focus:ring-red-500' : 'border-gray-300'
+            }`}
+          />
+          {errors.region && <p className="mt-1 text-sm text-red-600">{errors.region.message}</p>}
+        </div>
+
+        <div>
+          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="partner-status">
+            Status *
+          </label>
+          <select
+            id="partner-status"
+            {...register('status')}
+            className={`w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500 ${
+              errors.status ? 'border-red-500 focus:ring-red-500' : 'border-gray-300'
+            }`}
+          >
+            <option value="">Selecione</option>
+            {statusOptions.map((status) => (
+              <option key={status.value} value={status.value}>
+                {status.label}
+              </option>
+            ))}
+          </select>
+          {errors.status && <p className="mt-1 text-sm text-red-600">{errors.status.message}</p>}
+        </div>
+
+        <div>
+          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="partner-receipts-status">
+            Status dos Comprovantes *
+          </label>
+          <select
+            id="partner-receipts-status"
+            {...register('receiptsStatus')}
+            className={`w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500 ${
+              errors.receiptsStatus ? 'border-red-500 focus:ring-red-500' : 'border-gray-300'
+            }`}
+          >
+            <option value="">Selecione</option>
+            {receiptStatusOptions.map((status) => (
+              <option key={status.value} value={status.value}>
+                {status.label}
+              </option>
+            ))}
+          </select>
+          {errors.receiptsStatus && <p className="mt-1 text-sm text-red-600">{errors.receiptsStatus.message}</p>}
+        </div>
+
+        <div className="md:col-span-2">
+          <label className="mb-1 block text-sm font-medium text-gray-700">
+            Cidades de Atuação *
+          </label>
+          <Controller
+            control={control}
+            name="cities"
+            render={({ field }) => (
+              <CityChipsInput
+                value={field.value}
+                onChange={field.onChange}
+                suggestions={suggestions}
+                placeholder="Digite uma cidade e pressione Enter"
+                error={errors.cities?.message}
+              />
+            )}
+          />
+        </div>
+
+        <div className="md:col-span-2">
+          <h4 className="text-sm font-semibold text-gray-700">Dados do Responsável</h4>
+        </div>
+
+        <div>
+          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="partner-contact-name">
+            Nome *
+          </label>
+          <input
+            id="partner-contact-name"
+            {...register('contactName')}
+            placeholder="Nome do responsável"
+            className={`w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500 ${
+              errors.contactName ? 'border-red-500 focus:ring-red-500' : 'border-gray-300'
+            }`}
+          />
+          {errors.contactName && <p className="mt-1 text-sm text-red-600">{errors.contactName.message}</p>}
+        </div>
+
+        <div>
+          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="partner-contact-phone">
+            Telefone *
+          </label>
+          <input
+            id="partner-contact-phone"
+            {...register('contactPhone', {
+              onChange: (event) => {
+                const masked = applyPhoneMask(event.target.value);
+                event.target.value = masked;
+              },
+            })}
+            placeholder="(11) 99999-0000"
+            className={`w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500 ${
+              errors.contactPhone ? 'border-red-500 focus:ring-red-500' : 'border-gray-300'
+            }`}
+          />
+          {errors.contactPhone && <p className="mt-1 text-sm text-red-600">{errors.contactPhone.message}</p>}
+        </div>
+
+        <div>
+          <label className="mb-1 block text-sm font-medium text-gray-700" htmlFor="partner-contact-email">
+            Email *
+          </label>
+          <input
+            id="partner-contact-email"
+            type="email"
+            {...register('contactEmail')}
+            placeholder="contato@empresa.com.br"
+            className={`w-full rounded-lg border px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-green-500 ${
+              errors.contactEmail ? 'border-red-500 focus:ring-red-500' : 'border-gray-300'
+            }`}
+          />
+          {errors.contactEmail && <p className="mt-1 text-sm text-red-600">{errors.contactEmail.message}</p>}
+        </div>
+      </div>
+
+      {errors.root && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {errors.root.message}
+        </div>
+      )}
+
+      <div className="flex justify-end gap-3">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-green-500"
+        >
+          Cancelar
+        </button>
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="inline-flex items-center gap-2 rounded-lg bg-green-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:bg-green-400"
+        >
+          {isSubmitting && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
+          Salvar Parceiro
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default PartnerForm;

--- a/src/utils/masks.ts
+++ b/src/utils/masks.ts
@@ -1,0 +1,26 @@
+export function applyPhoneMask(value: string): string {
+  const digits = value.replace(/\D/g, '').slice(0, 11);
+
+  const areaCode = digits.slice(0, 2);
+  const middle = digits.length > 10 ? digits.slice(2, 7) : digits.slice(2, 6);
+  const suffix = digits.length > 10 ? digits.slice(7, 11) : digits.slice(6, 10);
+
+  if (digits.length <= 2) {
+    return digits;
+  }
+
+  if (digits.length <= 6) {
+    return `(${areaCode}) ${digits.slice(2)}`.trim();
+  }
+
+  if (digits.length <= 10) {
+    return `(${areaCode}) ${middle}-${suffix}`.trim();
+  }
+
+  return `(${areaCode}) ${middle}-${suffix}`.trim();
+}
+
+export function isValidPhone(value: string): boolean {
+  const digits = value.replace(/\D/g, '');
+  return digits.length >= 10 && digits.length <= 11;
+}


### PR DESCRIPTION
## Summary
- replace the drawer placeholder with company and partner forms wired to IPC create calls and store updates
- introduce React Hook Form + Zod form components with validation, phone masking, and status enforcement
- add a reusable chips autocomplete for cities alongside shared masking utilities

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d570e4ea1c832588184956df199f05