### PR TITLE
Refine pipeline kanban columns and card actions

### DIFF
--- a/src/components/common/ProgressBar.tsx
+++ b/src/components/common/ProgressBar.tsx
@@ -1,6 +1,6 @@
 import { cn } from '../../utils/cn';
 
-type ProgressTone = 'blue' | 'green' | 'yellow';
+export type ProgressTone = 'blue' | 'green' | 'yellow';
 
 type ProgressBarProps = {
   value: number;
@@ -15,8 +15,12 @@ const toneStyles: Record<ProgressTone, string> = {
   yellow: 'bg-yellow-500'
 };
 
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
 const ProgressBar = ({ value, total, tone = 'blue', className }: ProgressBarProps) => {
-  const percentage = Math.min(100, total > 0 ? (value / total) * 100 : 0);
+  const ratio = total > 0 ? value / total : 0;
+  const safeRatio = Number.isFinite(ratio) ? ratio : 0;
+  const percentage = clamp(safeRatio * 100, 0, 100);
 
   return (
     <div className={cn('mt-2 h-2 w-full rounded-full bg-gray-200', className)}>

--- a/src/constants/receiptStageMetadata.ts
+++ b/src/constants/receiptStageMetadata.ts
@@ -1,0 +1,33 @@
+import { CheckCircle, FileText, Upload, type LucideIcon } from 'lucide-react';
+import { RECEIPT_STAGES, type ReceiptStage } from '../types/entities';
+import type { ProgressTone } from '../components/common/ProgressBar';
+
+export type ReceiptStageMetadata = {
+  title: string;
+  tone: ProgressTone;
+  icon: LucideIcon;
+  progressLabel: string;
+};
+
+export const RECEIPT_STAGE_METADATA: Record<ReceiptStage, ReceiptStageMetadata> = {
+  recebimento: {
+    title: 'Recebimento de Comprovantes',
+    tone: 'blue',
+    icon: Upload,
+    progressLabel: 'comprovantes'
+  },
+  relatorio: {
+    title: 'Relatório Preenchido',
+    tone: 'yellow',
+    icon: FileText,
+    progressLabel: 'processados'
+  },
+  nota_fiscal: {
+    title: 'Nota Fiscal Pronta',
+    tone: 'green',
+    icon: CheckCircle,
+    progressLabel: 'finalizados'
+  }
+};
+
+export const RECEIPT_STAGE_ORDER = [...RECEIPT_STAGES];

--- a/src/store/useWaterDataStore.ts
+++ b/src/store/useWaterDataStore.ts
@@ -11,6 +11,7 @@ import {
   fetchPartners,
   fetchKanban
 } from '../services/dataService';
+import { RECEIPT_STAGES, type ReceiptStage } from '../types/entities';
 import { createStore } from './createStore';
 
 type LoadStatus = 'idle' | 'loading' | 'success' | 'error';
@@ -125,8 +126,8 @@ export const selectPartners = (state: WaterDataState): Partner[] =>
 
 export const selectKanbanColumns = (
   state: WaterDataState
-): Record<KanbanItem['stage'], KanbanItem[]> => ({
-  recebimento: state.kanban.byStage.recebimento.map((key) => state.kanban.items[key]),
-  relatorio: state.kanban.byStage.relatorio.map((key) => state.kanban.items[key]),
-  nota_fiscal: state.kanban.byStage.nota_fiscal.map((key) => state.kanban.items[key])
-});
+): Record<ReceiptStage, KanbanItem[]> =>
+  RECEIPT_STAGES.reduce<Record<ReceiptStage, KanbanItem[]>>((columns, stage) => {
+    columns[stage] = state.kanban.byStage[stage].map((key) => state.kanban.items[key]);
+    return columns;
+  }, {} as Record<ReceiptStage, KanbanItem[]>);


### PR DESCRIPTION
## Summary
- centralize receipt stage metadata (title, tone, icon) and use the enum ordering across the kanban view
- guard progress percentage calculations with Number.isFinite and clamp to the 0–100 range
- add contextual actions to kanban cards for moving stages, editing totals, and viewing history

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d57acb075083258b0a8452a5dac493