### PR TITLE
Ensure dev script waits for Electron output

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist-electron/main.js",
   "type": "commonjs",
   "scripts": {
-    "dev": "concurrently -k -r \"tsc -p electron/tsconfig.json --watch\" \"vite\" \"wait-on tcp:5173 && cross-env ELECTRON_RUN_AS_NODE=0 VITE_DEV_SERVER_URL=http://localhost:5173 electron .\"",
+    "dev": "concurrently -k -r \"tsc -p electron/tsconfig.json --watch\" \"vite\" \"wait-on dist-electron/main.js tcp:5173 && cross-env ELECTRON_RUN_AS_NODE=0 VITE_DEV_SERVER_URL=http://localhost:5173 electron .\"",
     "build": "vite build && tsc -p electron/tsconfig.json && electron-builder",
     "preview": "vite preview",
     "lint": "eslint ."


### PR DESCRIPTION
## Summary
- update the dev script so wait-on blocks on both the renderer port and the Electron bundle before launching

## Testing
- npm run dev *(fails in container: Electron requires libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d6999a790083258394be2ee098e14b