### PR TITLE
Adjust fallback logic for IPC data fetch

### DIFF
--- a/src/services/dataService.ts
+++ b/src/services/dataService.ts
@@ -191,7 +191,7 @@ async function fetchFromApi<T>(fallback: T, loader: (api: WindowApi) => Promise<
   if (!window.api) return fallback;
   try {
     const result = await loader(window.api);
-    if (!result || (Array.isArray(result) && result.length === 0)) {
+    if (result === null || result === undefined) {
       return fallback;
     }
     return result;


### PR DESCRIPTION
## Summary
- update fetchFromApi to only use fallback data when IPC responses are null or undefined
- ensure downstream fetch helpers continue returning empty collections without triggering the fallback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6a451c000832599a69abc88d5cc4a