### PR TITLE
feat: add optional store distribution by state

### DIFF
--- a/src/components/WaterDistributionSystem.tsx
+++ b/src/components/WaterDistributionSystem.tsx
@@ -473,6 +473,7 @@ const WaterDistributionSystem = () => {
           name: values.name,
           type: values.type,
           stores: values.stores,
+          storesByState: null,
           totalValue: values.totalValue,
           status: values.status,
           contact: {
@@ -1127,6 +1128,19 @@ const WaterDistributionSystem = () => {
   const renderCompanyDetails = () => {
     if (!selectedCompany) return null;
 
+    const storeEntries = selectedCompany.storesByState
+      ? Object.entries(selectedCompany.storesByState).filter(([, value]) => value > 0)
+      : [];
+    const hasStoreData = storeEntries.length > 0;
+    const stateColorClasses = [
+      'text-blue-600',
+      'text-green-600',
+      'text-purple-600',
+      'text-orange-600',
+      'text-teal-600',
+      'text-rose-600',
+    ];
+
     return (
       <OverlayDialog
         isOpen={Boolean(selectedCompany)}
@@ -1193,26 +1207,23 @@ const WaterDistributionSystem = () => {
 
           <div>
             <h3 className="mb-3 text-lg font-semibold">Lojas por Estado</h3>
-            <div className="rounded-lg bg-gray-50 p-4">
-              <div className="grid grid-cols-2 gap-4 text-sm md:grid-cols-4">
-                <div className="text-center">
-                  <p className="text-lg font-medium text-blue-600">25</p>
-                  <p className="text-gray-600">São Paulo</p>
-                </div>
-                <div className="text-center">
-                  <p className="text-lg font-medium text-green-600">18</p>
-                  <p className="text-gray-600">Rio de Janeiro</p>
-                </div>
-                <div className="text-center">
-                  <p className="text-lg font-medium text-purple-600">15</p>
-                  <p className="text-gray-600">Minas Gerais</p>
-                </div>
-                <div className="text-center">
-                  <p className="text-lg font-medium text-orange-600">31</p>
-                  <p className="text-gray-600">Outros Estados</p>
+            {hasStoreData ? (
+              <div className="rounded-lg bg-gray-50 p-4">
+                <div className="grid grid-cols-2 gap-4 text-sm md:grid-cols-4">
+                  {storeEntries.map(([state, count], index) => {
+                    const colorClass = stateColorClasses[index % stateColorClasses.length];
+                    return (
+                      <div key={state} className="text-center">
+                        <p className={`text-lg font-medium ${colorClass}`}>{count}</p>
+                        <p className="text-gray-600">{state}</p>
+                      </div>
+                    );
+                  })}
                 </div>
               </div>
-            </div>
+            ) : (
+              <p className="rounded-lg bg-gray-50 p-4 text-sm text-gray-600">Dados indisponíveis.</p>
+            )}
           </div>
         </div>
       </OverlayDialog>

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -18,6 +18,7 @@ export type Company = {
   name: string;
   type: string;
   stores: number;
+  storesByState: Record<string, number> | null;
   totalValue: number;
   status: Status;
   contact: Contact;

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -5,6 +5,7 @@ export type RawCompany = {
   name: string;
   type: string | null;
   stores: number | null;
+  stores_by_state_json: string | null;
   total_value: number | null;
   status: Status | null;
   contact_name: string | null;


### PR DESCRIPTION
## Summary
- add an optional stores-by-state map to company entities and raw IPC payloads
- parse and normalize state store data when loading companies, keeping fallbacks in sync
- update the company details drawer to render real store distributions or a fallback message

## Testing
- npm run lint *(fails: eslint config expects ESM and cannot be loaded under CommonJS)*
- npx tsc --noEmit *(fails: existing form components assign to read-only refs)*
- node - <<'NODE' ... *(manual check confirming fallback counts sum to total stores)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b61c69608325a6d1eb7a7966a99b