### PR TITLE
Configure CSP via environment variables

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+VITE_APP_CSP="default-src 'self' http://localhost:5173 ws://localhost:5173 data: blob:; script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:5173; style-src 'self' 'unsafe-inline' http://localhost:5173; img-src 'self' data: blob: http://localhost:5173; font-src 'self' data: http://localhost:5173; connect-src 'self' http://localhost:5173 ws://localhost:5173"

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,1 @@
+VITE_APP_CSP="default-src 'self'; script-src 'self'; style-src 'self' 'sha256-xhjkSSoP2uC3mAe4OUlU1PhABeO7bz3FQTfsd/44XKM='; img-src 'self' data:; font-src 'self' data:; connect-src 'self'"

--- a/index.html
+++ b/index.html
@@ -4,29 +4,8 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'sha256-xhjkSSoP2uC3mAe4OUlU1PhABeO7bz3FQTfsd/44XKM='; img-src 'self' data:; font-src 'self' data:; connect-src 'self' http://localhost:5173 ws://localhost:5173"
+      content="%VITE_APP_CSP%"
     />
-    <script type="module">
-      if (import.meta.env.DEV) {
-        const meta = document.querySelector(
-          "meta[http-equiv='Content-Security-Policy']"
-        );
-
-        if (meta) {
-          meta.setAttribute(
-            'content',
-            [
-              "default-src 'self' http://localhost:5173 ws://localhost:5173 data: blob:",
-              "script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:5173",
-              "style-src 'self' 'unsafe-inline' http://localhost:5173",
-              "img-src 'self' data: blob: http://localhost:5173",
-              "font-src 'self' data: http://localhost:5173",
-              "connect-src 'self' ws://localhost:5173 http://localhost:5173"
-            ].join('; ')
-          );
-        }
-      }
-    </script>
     <style id="base-style">#root{isolation:isolate;}</style>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>AquaDistrib Pro</title>


### PR DESCRIPTION
## Summary
- parameterize the CSP meta tag so it pulls from a Vite environment placeholder
- add development and production env files with permissive and hardened CSP values respectively

## Testing
- `npm run dev -- --host 0.0.0.0 --port 5173`
- `npm run build` *(fails: electron-builder cannot download better-sqlite3 prebuilt binaries in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6c5fc6b5c8325aeb09005918cc958