### PR TITLE
Add shared TypeScript typecheck scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,16 @@ npm ERR! gyp ERR! find VS Could not find any Visual Studio installation to use
 
 Following the steps above allows `npm install` to build `better-sqlite3`
 successfully, resolving the Visual Studio lookup error during installation.
+
+## Type checking
+
+Run the combined type-checking workflow across the renderer (Vite) and Electron
+processes with:
+
+```bash
+npm run typecheck
+```
+
+This command executes both `npm run typecheck:web` and `npm run typecheck:electron`
+to ensure TypeScript coverage for the entire application. Add it to your
+continuous integration workflow alongside linting to catch regressions early.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier . --write",
-    "format:check": "prettier . --check"
+    "format:check": "prettier . --check",
+    "typecheck:web": "tsc --noEmit",
+    "typecheck:electron": "tsc -p electron/tsconfig.json --noEmit",
+    "typecheck": "npm run typecheck:web && npm run typecheck:electron"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/src/components/forms/CompanyForm.tsx
+++ b/src/components/forms/CompanyForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, type MutableRefObject } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Loader2 } from 'lucide-react';
@@ -30,7 +30,7 @@ export type CompanyFormValues = z.infer<typeof companySchema>;
 type CompanyFormProps = {
   onSubmit: (values: CompanyFormValues) => Promise<void>;
   onCancel: () => void;
-  initialFocusRef?: React.RefObject<HTMLInputElement>;
+  initialFocusRef?: MutableRefObject<HTMLInputElement | null>;
 };
 
 const CompanyForm = ({ onSubmit, onCancel, initialFocusRef }: CompanyFormProps) => {

--- a/src/components/forms/PartnerForm.tsx
+++ b/src/components/forms/PartnerForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, type MutableRefObject } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Loader2 } from 'lucide-react';
@@ -32,7 +32,7 @@ type PartnerFormProps = {
   onSubmit: (values: PartnerFormValues) => Promise<void>;
   onCancel: () => void;
   suggestions: string[];
-  initialFocusRef?: React.RefObject<HTMLInputElement>;
+  initialFocusRef?: MutableRefObject<HTMLInputElement | null>;
 };
 
 const PartnerForm = ({ onSubmit, onCancel, suggestions, initialFocusRef }: PartnerFormProps) => {


### PR DESCRIPTION
## Summary
- add npm scripts that run TypeScript type checking for the renderer and Electron processes
- document the new combined typecheck workflow and recommend adding it to CI
- update focus refs in the forms to stay compatible with stricter type checking

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d6cb12a5ac8325adbdd4fe46d231e6