### PR TITLE
Add Vitest configuration and unit tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     "format:check": "prettier . --check",
     "typecheck:web": "tsc --noEmit",
     "typecheck:electron": "tsc -p electron/tsconfig.json --noEmit",
-    "typecheck": "npm run typecheck:web && npm run typecheck:electron"
+    "typecheck": "npm run typecheck:web && npm run typecheck:electron",
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -47,7 +50,13 @@
     "@typescript-eslint/eslint-plugin": "^8.12.2",
     "eslint-plugin-react": "^7.37.1",
     "eslint-plugin-react-hooks": "^5.1.0",
-    "eslint-plugin-react-refresh": "^0.4.11"
+    "eslint-plugin-react-refresh": "^0.4.11",
+    "vitest": "^2.1.1",
+    "@vitest/coverage-v8": "^2.1.1",
+    "jsdom": "^25.0.0",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/jest-dom": "^6.4.3",
+    "@testing-library/user-event": "^14.5.2"
   },
   "build": {
     "appId": "com.aquadistrib.pro",

--- a/src/components/__tests__/WaterDistributionSystem.table.test.tsx
+++ b/src/components/__tests__/WaterDistributionSystem.table.test.tsx
@@ -1,0 +1,322 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import userEvent from '@testing-library/user-event';
+import type {
+  Company,
+  NormalizedEntities,
+  NormalizedKanban,
+  Partner
+} from '../../services/dataService';
+
+vi.mock('../../hooks/useThemePreference', () => ({
+  useThemePreference: () => ({
+    preference: 'light',
+    resolvedTheme: 'light',
+    setPreference: vi.fn()
+  })
+}));
+
+vi.mock('../dashboard/StatCard', () => ({
+  default: ({ label }: { label: string }) => <div data-testid={`stat-${label}`} />
+}));
+
+vi.mock('../common/PartnerCard', () => ({
+  default: ({ partner }: { partner: Partner }) => (
+    <div data-testid={`partner-${partner.id}`}>{partner.name}</div>
+  )
+}));
+
+vi.mock('../common/ProgressBar', () => ({
+  default: ({ value }: { value: number }) => <div data-testid="progress">{value}</div>
+}));
+
+vi.mock('../common/BadgeStatus', () => ({
+  default: ({ label }: { label: string }) => <span>{label}</span>
+}));
+
+vi.mock('../common/ThemeToggle', () => ({
+  default: ({ onChange }: { onChange: (value: string) => void }) => (
+    <button type="button" onClick={() => onChange('light')}>
+      Alternar tema
+    </button>
+  )
+}));
+
+vi.mock('../forms/CompanyForm', () => ({
+  default: () => <div data-testid="company-form" />
+}));
+
+vi.mock('../forms/PartnerForm', () => ({
+  default: () => <div data-testid="partner-form" />
+}));
+
+vi.mock('../ui/OverlayDialog', () => ({
+  default: ({ isOpen, children, titleId }: { isOpen: boolean; children: ReactNode; titleId: string }) =>
+    isOpen ? (
+      <div role="dialog" aria-labelledby={titleId}>
+        {children}
+      </div>
+    ) : null
+}));
+
+vi.mock('../common/ToolbarTabs', () => ({
+  default: ({ tabs, onTabChange }: { tabs: Array<{ id: string; label: string }>; onTabChange: (tab: string) => void }) => (
+    <div>
+      {tabs.map((tab) => (
+        <button key={tab.id} type="button" onClick={() => onTabChange(tab.id)}>
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  )
+}));
+
+type LoadStatus = 'idle' | 'loading' | 'success' | 'error';
+
+type StoreState = {
+  companies: NormalizedEntities<Company>;
+  partners: NormalizedEntities<Partner>;
+  kanban: NormalizedKanban;
+  status: { companies: LoadStatus; partners: LoadStatus; kanban: LoadStatus };
+  errors: { companies: string | null; partners: string | null; kanban: string | null };
+  fetchCompanies: () => Promise<void>;
+  fetchPartners: () => Promise<void>;
+  fetchKanban: () => Promise<void>;
+  fetchAll: () => Promise<void>;
+};
+
+const createEmptyEntities = <T extends { id: number }>(): NormalizedEntities<T> => ({
+  byId: {},
+  allIds: []
+});
+
+const createEmptyKanban = (): NormalizedKanban => ({
+  items: {},
+  byStage: {
+    recebimento: [],
+    relatorio: [],
+    nota_fiscal: []
+  }
+});
+
+vi.mock('../../store/useWaterDataStore', () => {
+  let storeState: StoreState = {
+    companies: createEmptyEntities<Company>(),
+    partners: createEmptyEntities<Partner>(),
+    kanban: createEmptyKanban(),
+    status: { companies: 'success', partners: 'success', kanban: 'success' },
+    errors: { companies: null, partners: null, kanban: null },
+    fetchCompanies: async () => {},
+    fetchPartners: async () => {},
+    fetchKanban: async () => {},
+    fetchAll: async () => {}
+  };
+
+  const listeners = new Set<() => void>();
+
+  const useWaterDataStore = (<T>(selector?: (state: StoreState) => T) =>
+    selector ? selector(storeState) : (storeState as unknown as T)) as unknown as {
+    (): StoreState;
+    <TSelected>(selector: (state: StoreState) => TSelected): TSelected;
+    getState: () => StoreState;
+    setState: (updater: Partial<StoreState> | ((state: StoreState) => Partial<StoreState>), replace?: boolean) => void;
+    subscribe: (listener: () => void) => () => void;
+  };
+
+  useWaterDataStore.getState = () => storeState;
+  useWaterDataStore.setState = (updater, replace = false) => {
+    const nextState = typeof updater === 'function' ? updater(storeState) : updater;
+    storeState = replace
+      ? (nextState as StoreState)
+      : { ...storeState, ...(nextState as Partial<StoreState>) };
+    listeners.forEach((listener) => listener());
+  };
+  useWaterDataStore.subscribe = (listener: () => void) => {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  };
+
+  const selectCompanies = (state: StoreState) =>
+    state.companies.allIds.map((id) => state.companies.byId[id]);
+
+  const selectPartners = (state: StoreState) =>
+    state.partners.allIds.map((id) => state.partners.byId[id]);
+
+  const selectKanbanColumns = (state: StoreState) => ({
+    recebimento: state.kanban.byStage.recebimento.map((key) => state.kanban.items[key]),
+    relatorio: state.kanban.byStage.relatorio.map((key) => state.kanban.items[key]),
+    nota_fiscal: state.kanban.byStage.nota_fiscal.map((key) => state.kanban.items[key])
+  });
+
+  return {
+    useWaterDataStore,
+    selectCompanies,
+    selectPartners,
+    selectKanbanColumns,
+    __setStoreState: (next: StoreState) => {
+      storeState = next;
+      listeners.forEach((listener) => listener());
+    }
+  };
+});
+
+import WaterDistributionSystem from '../WaterDistributionSystem';
+import * as storeModule from '../../store/useWaterDataStore';
+
+const { __setStoreState } = storeModule as unknown as {
+  __setStoreState: (state: StoreState) => void;
+};
+
+const buildCompany = (id: number, overrides: Partial<Company> = {}): Company => {
+  const base: Company = {
+    id,
+    name: `Empresa ${id}`,
+    type: 'Moda',
+    stores: 10,
+    storesByState: null,
+    totalValue: 1000,
+    status: 'ativo',
+    contact: {
+      name: `Contato ${id}`,
+      phone: `(11) 90000-000${id}`,
+      email: `contato${id}@exemplo.com`
+    }
+  };
+
+  return {
+    ...base,
+    ...overrides,
+    contact: {
+      ...base.contact,
+      ...(overrides.contact ?? {})
+    }
+  };
+};
+
+const normalizeCompanies = (companies: Company[]): NormalizedEntities<Company> => {
+  const byId: Record<number, Company> = {};
+  const allIds: number[] = [];
+  companies.forEach((company) => {
+    byId[company.id] = company;
+    allIds.push(company.id);
+  });
+  return { byId, allIds };
+};
+
+const createStoreState = (companies: Company[]): StoreState => ({
+  companies: normalizeCompanies(companies),
+  partners: createEmptyEntities<Partner>(),
+  kanban: createEmptyKanban(),
+  status: { companies: 'success', partners: 'success', kanban: 'success' },
+  errors: { companies: null, partners: null, kanban: null },
+  fetchCompanies: async () => {},
+  fetchPartners: async () => {},
+  fetchKanban: async () => {},
+  fetchAll: async () => {}
+});
+
+const getTableRows = () => {
+  const table = screen.getByRole('table');
+  const tbody = table.querySelector('tbody');
+  if (!tbody) {
+    throw new Error('Tabela sem corpo');
+  }
+  return Array.from(tbody.querySelectorAll('tr')).filter((row) => row.querySelectorAll('td').length >= 6);
+};
+
+let intersectionCallbacks: Array<(entries: IntersectionObserverEntry[]) => void> = [];
+
+beforeEach(() => {
+  intersectionCallbacks = [];
+  class MockIntersectionObserver {
+    callback: IntersectionObserverCallback;
+    constructor(callback: IntersectionObserverCallback) {
+      this.callback = callback;
+    }
+    observe = () => {
+      intersectionCallbacks.push(this.callback);
+    };
+    unobserve = () => {};
+    disconnect = () => {};
+  }
+  vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+  __setStoreState(createStoreState([]));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('WaterDistributionSystem companies table', () => {
+  it('filters companies by search term and status', async () => {
+    const companies = [
+      buildCompany(1, { name: 'Aquarius', contact: { name: 'Alice' } }),
+      buildCompany(2, { name: 'Beta Distribuidora', status: 'inativo', contact: { name: 'Bruno' } })
+    ];
+    __setStoreState(createStoreState(companies));
+
+    const user = userEvent.setup();
+    render(<WaterDistributionSystem />);
+
+    await user.click(screen.getByRole('button', { name: /Empresas/i }));
+
+    await user.type(screen.getByLabelText(/Buscar/i), 'aqua');
+    let rows = getTableRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveTextContent('Aquarius');
+
+    await user.clear(screen.getByLabelText(/Buscar/i));
+    await user.selectOptions(screen.getByLabelText(/Status/i), 'inativo');
+
+    rows = getTableRows();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toHaveTextContent('Beta Distribuidora');
+  });
+
+  it('allows sorting by stores in descending order', async () => {
+    const companies = [
+      buildCompany(1, { name: 'Atlas', stores: 5 }),
+      buildCompany(2, { name: 'Boreal', stores: 20 }),
+      buildCompany(3, { name: 'Cosmos', stores: 12 })
+    ];
+    __setStoreState(createStoreState(companies));
+
+    const user = userEvent.setup();
+    render(<WaterDistributionSystem />);
+
+    await user.click(screen.getByRole('button', { name: /Empresas/i }));
+
+    const storesButton = screen.getByRole('button', { name: /Lojas/i });
+    await user.click(storesButton);
+    await user.click(storesButton);
+
+    const rows = getTableRows();
+    expect(rows[0]).toHaveTextContent('Boreal');
+
+    const storesHeader = screen.getByRole('columnheader', { name: /Lojas/i });
+    expect(storesHeader).toHaveAttribute('aria-sort', 'descending');
+  });
+
+  it('increases pagination when the sentinel becomes visible', async () => {
+    const companies = Array.from({ length: 12 }, (_, index) =>
+      buildCompany(index + 1, { name: `Empresa ${String.fromCharCode(65 + index)}`, stores: index + 1 })
+    );
+    __setStoreState(createStoreState(companies));
+
+    const user = userEvent.setup();
+    render(<WaterDistributionSystem />);
+
+    await user.click(screen.getByRole('button', { name: /Empresas/i }));
+
+    expect(getTableRows()).toHaveLength(10);
+
+    intersectionCallbacks.forEach((callback) =>
+      callback([{ isIntersecting: true } as IntersectionObserverEntry])
+    );
+
+    await waitFor(() => {
+      expect(getTableRows()).toHaveLength(12);
+    });
+  });
+});

--- a/src/components/ui/__tests__/OverlayDialog.test.tsx
+++ b/src/components/ui/__tests__/OverlayDialog.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef } from 'react';
+import OverlayDialog from '../OverlayDialog';
+
+describe('OverlayDialog', () => {
+  it('focuses the provided initial element when opened', async () => {
+    const onClose = vi.fn();
+    const initialFocusRef = createRef<HTMLButtonElement>();
+
+    render(
+      <OverlayDialog
+        isOpen
+        onClose={onClose}
+        titleId="dialog-title"
+        initialFocusRef={initialFocusRef}
+      >
+        <button ref={initialFocusRef}>Primeiro botão</button>
+        <button>Segundo botão</button>
+      </OverlayDialog>
+    );
+
+    await screen.findByRole('dialog');
+    expect(initialFocusRef.current).not.toBeNull();
+    await waitFor(() => {
+      expect(initialFocusRef.current).toHaveFocus();
+    });
+  });
+
+  it('closes when pressing Escape and when clicking on the overlay', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+
+    render(
+      <OverlayDialog isOpen onClose={onClose} titleId="dialog-title">
+        <button>Conteúdo</button>
+      </OverlayDialog>
+    );
+
+    const overlay = screen.getByRole('dialog');
+
+    await user.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    await user.click(overlay);
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it('applies variant-specific classes for modal and drawer modes', () => {
+    const { rerender } = render(
+      <OverlayDialog isOpen onClose={vi.fn()} titleId="modal">
+        <div>Modal content</div>
+      </OverlayDialog>
+    );
+
+    const modalOverlay = screen.getByRole('dialog');
+    const modalPanel = modalOverlay.firstElementChild as HTMLElement | null;
+    expect(modalPanel).not.toBeNull();
+    expect(modalPanel).toHaveClass('rounded-lg');
+
+    rerender(
+      <OverlayDialog
+        isOpen
+        onClose={vi.fn()}
+        titleId="drawer"
+        variant="drawer"
+        position="left"
+        size="sm"
+      >
+        <div>Drawer content</div>
+      </OverlayDialog>
+    );
+
+    const drawerOverlay = screen.getByRole('dialog');
+    const drawerPanel = drawerOverlay.firstElementChild as HTMLElement | null;
+    expect(drawerPanel).not.toBeNull();
+    expect(drawerPanel).toHaveClass('h-full');
+    expect(drawerPanel).toHaveClass('ml-0');
+  });
+});

--- a/src/services/__tests__/dataService.test.ts
+++ b/src/services/__tests__/dataService.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  adaptCompany,
+  adaptKanbanItem,
+  adaptPartner,
+  fetchFromApi,
+  normalizeEntities,
+  type Company,
+  type KanbanItem,
+  type Partner
+} from '../dataService';
+import type { RawCompany, RawKanbanItem, RawPartner, WindowApi } from '../../types/ipc';
+
+declare global {
+  interface Window {
+    api?: WindowApi;
+  }
+}
+
+describe('dataService adapters', () => {
+  it('adapts companies including stores by state and fallbacks', () => {
+    const raw: RawCompany = {
+      id: 1,
+      name: 'ACME',
+      type: null,
+      stores: null,
+      stores_by_state_json: '{"SP": 5, "RJ": "7"}',
+      total_value: '1200.5' as unknown as number,
+      status: null,
+      contact_name: null,
+      contact_phone: undefined,
+      contact_email: undefined
+    };
+
+    const company = adaptCompany(raw);
+    expect(company).toMatchObject<Partial<Company>>({
+      id: 1,
+      name: 'ACME',
+      type: '',
+      stores: 0,
+      storesByState: { SP: 5, RJ: 7 },
+      totalValue: 1200.5,
+      status: 'ativo',
+      contact: { name: '', phone: '', email: '' }
+    });
+  });
+
+  it('returns null storesByState when JSON is invalid', () => {
+    const raw: RawCompany = {
+      id: 2,
+      name: 'Broken',
+      type: 'Tipo',
+      stores: 10,
+      stores_by_state_json: 'not-json',
+      total_value: 5000,
+      status: 'inativo',
+      contact_name: 'Contato',
+      contact_phone: '123',
+      contact_email: 'mail@example.com'
+    };
+
+    expect(adaptCompany(raw).storesByState).toBeNull();
+  });
+
+  it('adapts partners parsing cities safely', () => {
+    const raw: RawPartner = {
+      id: 1,
+      name: 'Partner',
+      region: null,
+      cities_json: '["A", "B"]',
+      contact_name: null,
+      contact_phone: undefined,
+      contact_email: undefined,
+      status: null,
+      receipts_status: null
+    };
+
+    const partner = adaptPartner(raw);
+    expect(partner).toMatchObject<Partial<Partner>>({
+      id: 1,
+      region: '',
+      cities: ['A', 'B'],
+      status: 'ativo',
+      receiptsStatus: 'pendente'
+    });
+  });
+
+  it('returns empty cities array for malformed JSON', () => {
+    const raw: RawPartner = {
+      id: 2,
+      name: 'Partner',
+      region: 'Nordeste',
+      cities_json: 'oops',
+      contact_name: 'Ana',
+      contact_phone: '123',
+      contact_email: 'ana@example.com',
+      status: 'ativo',
+      receipts_status: 'enviado'
+    };
+
+    expect(adaptPartner(raw).cities).toEqual([]);
+  });
+
+  it('creates kanban items with composite keys', () => {
+    const raw: RawKanbanItem = { company: 'ACME', stage: 'recebimento', receipts: 5, total: 10 };
+    const item = adaptKanbanItem(raw);
+    expect(item).toEqual<KanbanItem>({
+      key: 'ACME:recebimento',
+      company: 'ACME',
+      stage: 'recebimento',
+      receipts: 5,
+      total: 10
+    });
+  });
+});
+
+describe('normalizeEntities', () => {
+  it('normalizes entity arrays by id', () => {
+    const items = [
+      { id: 2, value: 'b' },
+      { id: 1, value: 'a' }
+    ];
+
+    const normalized = normalizeEntities(items);
+    expect(normalized.allIds).toEqual([2, 1]);
+    expect(normalized.byId[1]).toEqual({ id: 1, value: 'a' });
+  });
+});
+
+describe('fetchFromApi', () => {
+  const originalApi = window.api;
+
+  beforeEach(() => {
+    window.api = undefined;
+  });
+
+  afterEach(() => {
+    window.api = originalApi;
+    vi.restoreAllMocks();
+  });
+
+  it('returns fallback when api is unavailable', async () => {
+    const fallback = ['fallback'];
+    const result = await fetchFromApi(fallback, async () => ['remote']);
+    expect(result).toBe(fallback);
+  });
+
+  it('returns fetched data when available', async () => {
+    const fallback = ['fallback'];
+    const loader = vi.fn().mockResolvedValue(['remote']);
+    window.api = { companies: { list: vi.fn() } } as unknown as WindowApi;
+
+    const result = await fetchFromApi(fallback, loader);
+    expect(result).toEqual(['remote']);
+    expect(loader).toHaveBeenCalledWith(window.api);
+  });
+
+  it('falls back when loader resolves to null or throws', async () => {
+    const fallback = ['fallback'];
+    const loader = vi.fn().mockResolvedValue(null);
+    window.api = {} as WindowApi;
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const nullResult = await fetchFromApi(fallback, loader);
+    expect(nullResult).toBe(fallback);
+
+    loader.mockRejectedValueOnce(new Error('boom'));
+    const errorResult = await fetchFromApi(fallback, loader);
+    expect(errorResult).toBe(fallback);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/src/services/dataService.ts
+++ b/src/services/dataService.ts
@@ -278,3 +278,5 @@ export function createEmptyKanban(): NormalizedKanban {
     byStage: createEmptyStageMap(),
   };
 }
+
+export { adaptCompany, adaptPartner, adaptKanbanItem, normalizeEntities, fetchFromApi };

--- a/src/utils/__tests__/formatters.test.ts
+++ b/src/utils/__tests__/formatters.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { formatCurrency, formatEmail, formatPhone } from '../formatters';
+
+const normalizeCurrency = (value: string) => value.replace(/\s+/g, ' ').trim();
+
+describe('formatCurrency', () => {
+  it('formats positive numbers using BRL locale', () => {
+    const formatted = formatCurrency(1234.5);
+    expect(normalizeCurrency(formatted)).toContain('R$');
+    expect(normalizeCurrency(formatted)).toContain('1.234,50');
+  });
+
+  it('formats negative numbers preserving the sign', () => {
+    const formatted = formatCurrency(-987.65);
+    expect(normalizeCurrency(formatted)).toContain('R$');
+    expect(normalizeCurrency(formatted)).toContain('987,65');
+    expect(formatted.trim().startsWith('-')).toBe(true);
+  });
+
+  it('falls back to zero when value is null, undefined or NaN', () => {
+    expect(formatCurrency(null)).toBe(formatCurrency(0));
+    expect(formatCurrency(undefined)).toBe(formatCurrency(0));
+    expect(formatCurrency(Number.NaN)).toBe(formatCurrency(0));
+  });
+});
+
+describe('formatPhone', () => {
+  it('returns normalized phone when provided', () => {
+    expect(formatPhone('  (11) 99999-9999  ')).toBe('(11) 99999-9999');
+  });
+
+  it('returns fallback when value is nullish or empty', () => {
+    expect(formatPhone(null)).toBe('Não informado');
+    expect(formatPhone(undefined)).toBe('Não informado');
+    expect(formatPhone('   ')).toBe('Não informado');
+  });
+});
+
+describe('formatEmail', () => {
+  it('returns normalized email when provided', () => {
+    expect(formatEmail(' user@example.com ')).toBe('user@example.com');
+  });
+
+  it('returns fallback when value is nullish or empty', () => {
+    expect(formatEmail(null)).toBe('Não informado');
+    expect(formatEmail(undefined)).toBe('Não informado');
+    expect(formatEmail('')).toBe('Não informado');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,14 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   plugins: [react()],
   build: { outDir: 'dist' },
-  server: { port: 5173 }
+  server: { port: 5173 },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './vitest.setup.ts',
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html', 'lcov']
+    }
+  }
 });

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,12 @@
+import '@testing-library/jest-dom';
+
+declare global {
+  // Vitest with jsdom doesn't provide crypto.randomUUID in older environments
+  interface Crypto {
+    randomUUID?: () => string;
+  }
+}
+
+if (typeof globalThis.crypto !== 'undefined' && !globalThis.crypto.randomUUID) {
+  globalThis.crypto.randomUUID = () => `test-${Math.random().toString(16).slice(2)}`;
+}


### PR DESCRIPTION
## Summary
- configure Vitest scripts, dependencies, and Vite test runner integration
- add a Vitest setup file and expose data service helpers needed for isolated testing
- write unit tests covering formatters, data service adapters, OverlayDialog focus/close behavior, and WaterDistributionSystem table interactions

## Testing
- npm run test *(fails: `vitest` executable not found because test dependencies could not be installed in this environment)*
- npm run test:coverage *(fails: `vitest` executable not found because test dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6cd0a1bc48325af3a550bb9b7d358