### PR TITLE
Add Playwright E2E tests for companies flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm run test -- --run
+
+      - name: End-to-end tests
+        run: npm run test:e2e

--- a/README.md
+++ b/README.md
@@ -54,3 +54,24 @@ npm run typecheck
 This command executes both `npm run typecheck:web` and `npm run typecheck:electron`
 to ensure TypeScript coverage for the entire application. Add it to your
 continuous integration workflow alongside linting to catch regressions early.
+
+## End-to-end testing
+
+Playwright drives the browser to exercise the renderer. Before running the
+suite for the first time install the required browser binaries:
+
+```bash
+npx playwright install
+```
+
+Execute the end-to-end scenarios with:
+
+```bash
+npm run test:e2e
+```
+
+To iterate locally with the inspector UI use:
+
+```bash
+npm run test:e2e:ui
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "eslint": "^9.11.1",
         "typescript": "^5.6.3",
         "vite": "^5.4.8",
-        "wait-on": "^8.0.1"
+        "wait-on": "^8.0.1",
+        "@playwright/test": "^1.48.2"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "typecheck": "npm run typecheck:web && npm run typecheck:electron",
     "test": "vitest",
     "test:watch": "vitest --watch",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
@@ -56,7 +58,8 @@
     "jsdom": "^25.0.0",
     "@testing-library/react": "^16.0.0",
     "@testing-library/jest-dom": "^6.4.3",
-    "@testing-library/user-event": "^14.5.2"
+    "@testing-library/user-event": "^14.5.2",
+    "@playwright/test": "^1.48.2"
   },
   "build": {
     "appId": "com.aquadistrib.pro",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 30_000,
+  expect: {
+    timeout: 10_000,
+  },
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: process.env.CI ? 'xvfb-run -a npm run dev' : 'npm run dev',
+    url: 'http://localhost:5173',
+    timeout: 120_000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/src/components/WaterDistributionSystem.tsx
+++ b/src/components/WaterDistributionSystem.tsx
@@ -710,6 +710,7 @@ const WaterDistributionSystem = () => {
         <button
           onClick={handleOpenCompanyForm}
           className="flex items-center space-x-2 rounded-lg bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+          data-testid="add-company-button"
         >
           <Plus size={20} />
           <span>Nova Empresa</span>
@@ -1432,6 +1433,7 @@ const WaterDistributionSystem = () => {
             <div
               key={toast.id}
               className={`rounded-lg border p-4 shadow-md transition ${toastToneStyles[toast.tone]}`}
+              data-testid="toast-message"
             >
               <div className="flex items-start justify-between">
                 <span className="text-sm font-medium">{toast.message}</span>

--- a/tests/e2e/companies.spec.ts
+++ b/tests/e2e/companies.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+
+const COMPANY_NAME = 'Playwright Test Company';
+
+test.describe('Companies management', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Empresas' }).click();
+    await expect(page.getByRole('heading', { name: 'Empresas Cadastradas' })).toBeVisible();
+  });
+
+  test('allows creating a new company from the drawer form', async ({ page }) => {
+    await page.getByTestId('add-company-button').click();
+
+    await expect(page.getByRole('heading', { name: 'Nova Empresa' })).toBeVisible();
+
+    await page.getByLabel('Nome da Empresa *').fill(COMPANY_NAME);
+    await page.getByLabel('Tipo de Negócio *').fill('Tecnologia');
+    await page.getByLabel('Número de Lojas *').fill('5');
+    await page.getByLabel('Valor Total Mensal (R$) *').fill('12345');
+    await page.getByLabel('Status *').selectOption('ativo');
+    await page.getByLabel('Nome *').fill('Joana Testadora');
+    await page.getByLabel('Telefone *').fill('11988887777');
+    await page.getByLabel('Email do Responsável *').fill('joana@example.com');
+
+    await page.getByRole('button', { name: 'Salvar Empresa' }).click();
+
+    const successToast = page
+      .getByTestId('toast-message')
+      .filter({ hasText: `Empresa ${COMPANY_NAME} cadastrada com sucesso.` });
+    await expect(successToast).toBeVisible();
+
+    await expect(page.getByRole('row', { name: new RegExp(COMPANY_NAME) })).toBeVisible();
+  });
+
+  test('shows feedback when editing and deleting companies', async ({ page }) => {
+    const editTarget = 'ANIMALE';
+    const deleteTarget = 'AREZZO';
+
+    await page.getByRole('button', { name: `Editar empresa ${editTarget}` }).click();
+    await expect(
+      page
+        .getByTestId('toast-message')
+        .filter({ hasText: `Empresa ${editTarget} atualizada com sucesso.` })
+    ).toBeVisible();
+
+    await page.getByRole('button', { name: `Excluir empresa ${deleteTarget}` }).click();
+    await expect(
+      page
+        .getByTestId('toast-message')
+        .filter({ hasText: `Empresa ${deleteTarget} excluída.` })
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add a Playwright configuration and browser-driven scenarios for managing companies
- expose test identifiers and documentation for the new e2e workflow
- wire the Playwright suite into the CI pipeline alongside existing checks

## Testing
- npm run lint *(fails: missing @typescript-eslint/parser in the offline container)*
- npm run test:e2e *(fails: Playwright CLI is unavailable in the offline container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d10f3a58832591a8feb227680446