### PR TITLE
Enable editing and deletion for companies

### DIFF
--- a/src/components/forms/CompanyForm.tsx
+++ b/src/components/forms/CompanyForm.tsx
@@ -31,9 +31,28 @@ type CompanyFormProps = {
   onSubmit: (values: CompanyFormValues) => Promise<void>;
   onCancel: () => void;
   initialFocusRef?: MutableRefObject<HTMLInputElement | null>;
+  initialValues?: CompanyFormValues | null;
+  submitLabel?: string;
 };
 
-const CompanyForm = ({ onSubmit, onCancel, initialFocusRef }: CompanyFormProps) => {
+const DEFAULT_VALUES: CompanyFormValues = {
+  name: '',
+  type: '',
+  stores: 0,
+  totalValue: 0,
+  status: 'ativo',
+  contactName: '',
+  contactPhone: '',
+  contactEmail: ''
+};
+
+const CompanyForm = ({
+  onSubmit,
+  onCancel,
+  initialFocusRef,
+  initialValues,
+  submitLabel = 'Salvar Empresa'
+}: CompanyFormProps) => {
   const {
     register,
     handleSubmit,
@@ -42,35 +61,21 @@ const CompanyForm = ({ onSubmit, onCancel, initialFocusRef }: CompanyFormProps) 
     formState: { errors, isSubmitting },
   } = useForm<CompanyFormValues>({
     resolver: zodResolver(companySchema),
-    defaultValues: {
-      name: '',
-      type: '',
-      stores: 0,
-      totalValue: 0,
-      status: 'ativo',
-      contactName: '',
-      contactPhone: '',
-      contactEmail: '',
-    },
+    defaultValues: initialValues ?? DEFAULT_VALUES,
   });
 
   useEffect(() => {
-    return () => reset();
+    return () => reset(DEFAULT_VALUES);
   }, [reset]);
+
+  useEffect(() => {
+    reset(initialValues ?? DEFAULT_VALUES);
+  }, [initialValues, reset]);
 
   const onFormSubmit = handleSubmit(async (values) => {
     try {
       await onSubmit(values);
-      reset({
-        name: '',
-        type: '',
-        stores: 0,
-        totalValue: 0,
-        status: 'ativo',
-        contactName: '',
-        contactPhone: '',
-        contactEmail: '',
-      });
+      reset(initialValues ?? DEFAULT_VALUES);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Não foi possível salvar a empresa.';
       setError('root', { type: 'manual', message });
@@ -254,7 +259,7 @@ const CompanyForm = ({ onSubmit, onCancel, initialFocusRef }: CompanyFormProps) 
           className="inline-flex items-center gap-2 rounded-lg bg-blue-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:bg-blue-400"
         >
           {isSubmitting && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
-          Salvar Empresa
+          {submitLabel}
         </button>
       </div>
     </form>

--- a/src/store/useWaterDataStore.ts
+++ b/src/store/useWaterDataStore.ts
@@ -46,6 +46,7 @@ type WaterDataState = {
   fetchAll: () => Promise<void>;
   createCompany: (input: CompanyInput) => Promise<Company>;
   updateCompany: (id: number, input: CompanyInput) => Promise<Company>;
+  deleteCompany: (id: number) => Promise<void>;
   createPartner: (input: PartnerInput) => Promise<Partner>;
   updatePartner: (id: number, input: PartnerInput) => Promise<Partner>;
   moveKanbanItem: (key: string, nextStage: ReceiptStage) => Promise<KanbanItem>;
@@ -222,6 +223,29 @@ export const useWaterDataStore = createStore<WaterDataState>((set, get) => ({
     }));
 
     return company;
+  },
+  async deleteCompany(id) {
+    const existing = get().companies.byId[id];
+    if (!existing) {
+      throw new Error('Empresa não encontrada.');
+    }
+
+    if (window.api?.companies?.delete) {
+      const response = await window.api.companies.delete(id);
+      if (!response || response.ok !== true) {
+        throw new Error('Não foi possível excluir a empresa.');
+      }
+    }
+
+    set((current) => {
+      const { [id]: _removed, ...remaining } = current.companies.byId;
+      return {
+        companies: {
+          byId: remaining,
+          allIds: current.companies.allIds.filter((companyId) => companyId !== id)
+        }
+      };
+    });
   },
   async createPartner(input) {
     const payload = {

--- a/src/views/companies/EntityFormDialog.tsx
+++ b/src/views/companies/EntityFormDialog.tsx
@@ -6,16 +6,23 @@ import type { DialogsViewModel } from '../../controllers/waterDistributionContro
 const EntityFormDialog = ({
   isOpen,
   type,
+  mode,
   titleId,
   initialFocusRef,
   onClose,
   onSubmitCompany,
   onSubmitPartner,
-  citySuggestions
+  citySuggestions,
+  companyInitialValues
 }: DialogsViewModel['form']) => {
   if (!isOpen) return null;
 
-  const title = type === 'company' ? 'Nova Empresa' : 'Novo Parceiro';
+  const title =
+    type === 'company'
+      ? mode === 'edit'
+        ? 'Editar Empresa'
+        : 'Nova Empresa'
+      : 'Novo Parceiro';
 
   return (
     <OverlayDialog
@@ -43,7 +50,13 @@ const EntityFormDialog = ({
       </div>
       <div className="p-6">
         {type === 'company' ? (
-          <CompanyForm onSubmit={onSubmitCompany} onCancel={onClose} initialFocusRef={initialFocusRef} />
+          <CompanyForm
+            onSubmit={onSubmitCompany}
+            onCancel={onClose}
+            initialFocusRef={initialFocusRef}
+            initialValues={companyInitialValues}
+            submitLabel={mode === 'edit' ? 'Atualizar Empresa' : 'Salvar Empresa'}
+          />
         ) : (
           <PartnerForm
             onSubmit={onSubmitPartner}


### PR DESCRIPTION
## Summary
- add a deleteCompany action to the water data store that also calls the IPC bridge
- expose update/delete methods through the controller and implement edit/delete flows with error handling and toasts
- update the company form dialog to support edit mode, prefill values, and adjust titles/labels

## Testing
- npm run lint *(fails: missing @eslint/js in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d70318bf188325a3524a8d843b5b76