### PR TITLE
Support editing mode initial values in entity forms

### DIFF
--- a/src/components/forms/CompanyForm.tsx
+++ b/src/components/forms/CompanyForm.tsx
@@ -65,17 +65,13 @@ const CompanyForm = ({
   });
 
   useEffect(() => {
-    return () => reset(DEFAULT_VALUES);
-  }, [reset]);
-
-  useEffect(() => {
     reset(initialValues ?? DEFAULT_VALUES);
   }, [initialValues, reset]);
 
   const onFormSubmit = handleSubmit(async (values) => {
     try {
       await onSubmit(values);
-      reset(initialValues ?? DEFAULT_VALUES);
+      reset(initialValues ? values : DEFAULT_VALUES);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Não foi possível salvar a empresa.';
       setError('root', { type: 'manual', message });

--- a/src/components/forms/PartnerForm.tsx
+++ b/src/components/forms/PartnerForm.tsx
@@ -33,9 +33,29 @@ type PartnerFormProps = {
   onCancel: () => void;
   suggestions: string[];
   initialFocusRef?: MutableRefObject<HTMLInputElement | null>;
+  initialValues?: PartnerFormValues | null;
+  submitLabel?: string;
 };
 
-const PartnerForm = ({ onSubmit, onCancel, suggestions, initialFocusRef }: PartnerFormProps) => {
+const DEFAULT_VALUES: PartnerFormValues = {
+  name: '',
+  region: '',
+  status: 'ativo',
+  receiptsStatus: 'pendente',
+  contactName: '',
+  contactPhone: '',
+  contactEmail: '',
+  cities: [],
+};
+
+const PartnerForm = ({
+  onSubmit,
+  onCancel,
+  suggestions,
+  initialFocusRef,
+  initialValues,
+  submitLabel = 'Salvar Parceiro'
+}: PartnerFormProps) => {
   const {
     control,
     register,
@@ -45,33 +65,17 @@ const PartnerForm = ({ onSubmit, onCancel, suggestions, initialFocusRef }: Partn
     formState: { errors, isSubmitting },
   } = useForm<PartnerFormValues>({
     resolver: zodResolver(partnerSchema),
-    defaultValues: {
-      name: '',
-      region: '',
-      status: 'ativo',
-      receiptsStatus: 'pendente',
-      contactName: '',
-      contactPhone: '',
-      contactEmail: '',
-      cities: [],
-    },
+    defaultValues: initialValues ?? DEFAULT_VALUES,
   });
 
-  useEffect(() => () => reset(), [reset]);
+  useEffect(() => {
+    reset(initialValues ?? DEFAULT_VALUES);
+  }, [initialValues, reset]);
 
   const onFormSubmit = handleSubmit(async (values) => {
     try {
       await onSubmit(values);
-      reset({
-        name: '',
-        region: '',
-        status: 'ativo',
-        receiptsStatus: 'pendente',
-        contactName: '',
-        contactPhone: '',
-        contactEmail: '',
-        cities: [],
-      });
+      reset(initialValues ? values : DEFAULT_VALUES);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Não foi possível salvar o parceiro.';
       setError('root', { type: 'manual', message });
@@ -274,7 +278,7 @@ const PartnerForm = ({ onSubmit, onCancel, suggestions, initialFocusRef }: Partn
           className="inline-flex items-center gap-2 rounded-lg bg-green-500 px-4 py-2 text-sm font-semibold text-white transition hover:bg-green-600 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-1 disabled:cursor-not-allowed disabled:bg-green-400"
         >
           {isSubmitting && <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />}
-          Salvar Parceiro
+          {submitLabel}
         </button>
       </div>
     </form>

--- a/src/controllers/waterDistributionController.ts
+++ b/src/controllers/waterDistributionController.ts
@@ -157,6 +157,7 @@ export type DialogsViewModel = {
     citySuggestions: string[];
     company: Company | null;
     companyInitialValues: CompanyFormValues | null;
+    partnerInitialValues: PartnerFormValues | null;
   };
 };
 
@@ -802,7 +803,7 @@ export const useWaterDistributionController = (): WaterDistributionController =>
     form: {
       isOpen: showForm,
       type: formType,
-      mode: editingCompany ? 'edit' : 'create',
+      mode: formType === 'company' && editingCompany ? 'edit' : 'create',
       titleId: formDialogTitleId,
       initialFocusRef: formInitialFieldRef,
       onClose: handleCloseForm,
@@ -810,7 +811,8 @@ export const useWaterDistributionController = (): WaterDistributionController =>
       onSubmitPartner: handlePartnerFormSubmit,
       citySuggestions,
       company: editingCompany,
-      companyInitialValues: companyFormInitialValues
+      companyInitialValues: formType === 'company' ? companyFormInitialValues : null,
+      partnerInitialValues: null
     }
   };
 

--- a/src/views/companies/EntityFormDialog.tsx
+++ b/src/views/companies/EntityFormDialog.tsx
@@ -13,7 +13,8 @@ const EntityFormDialog = ({
   onSubmitCompany,
   onSubmitPartner,
   citySuggestions,
-  companyInitialValues
+  companyInitialValues,
+  partnerInitialValues
 }: DialogsViewModel['form']) => {
   if (!isOpen) return null;
 
@@ -22,7 +23,18 @@ const EntityFormDialog = ({
       ? mode === 'edit'
         ? 'Editar Empresa'
         : 'Nova Empresa'
-      : 'Novo Parceiro';
+      : mode === 'edit'
+        ? 'Editar Parceiro'
+        : 'Novo Parceiro';
+
+  const submitLabel =
+    type === 'company'
+      ? mode === 'edit'
+        ? 'Atualizar Empresa'
+        : 'Salvar Empresa'
+      : mode === 'edit'
+        ? 'Atualizar Parceiro'
+        : 'Salvar Parceiro';
 
   return (
     <OverlayDialog
@@ -55,7 +67,7 @@ const EntityFormDialog = ({
             onCancel={onClose}
             initialFocusRef={initialFocusRef}
             initialValues={companyInitialValues}
-            submitLabel={mode === 'edit' ? 'Atualizar Empresa' : 'Salvar Empresa'}
+            submitLabel={submitLabel}
           />
         ) : (
           <PartnerForm
@@ -63,6 +75,8 @@ const EntityFormDialog = ({
             onCancel={onClose}
             suggestions={citySuggestions}
             initialFocusRef={initialFocusRef}
+            initialValues={partnerInitialValues}
+            submitLabel={submitLabel}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary
- update the entity form dialog to accept company and partner initial values, pick the right submit label, and adjust the dialog title based on the mode
- allow the company and partner forms to hydrate from incoming initial values and avoid clearing edited data after submit
- propagate the proper mode and initial values from the controller when opening the dialog in edit scenarios

## Testing
- npm run typecheck:web *(fails: existing TypeScript parse errors in test files)*

------
https://chatgpt.com/codex/tasks/task_e_68d7059fe5088325831a3bc42c6fda37