### PR TITLE
Enable editing existing partners from partners view

### DIFF
--- a/src/components/__tests__/WaterDistributionSystem.table.test.tsx
+++ b/src/components/__tests__/WaterDistributionSystem.table.test.tsx
@@ -130,7 +130,7 @@ vi.mock('../../store/useWaterDataStore', () => {
 
   const listeners = new Set<() => void>();
 
-  const useWaterDataStore = (<T>(selector?: (state: StoreState) => T) =>
+  const useWaterDataStore = (<T,>(selector?: (state: StoreState) => T) =>
     selector ? selector(storeState) : (storeState as unknown as T)) as unknown as {
     (): StoreState;
     <TSelected>(selector: (state: StoreState) => TSelected): TSelected;

--- a/src/views/partners/PartnersView.tsx
+++ b/src/views/partners/PartnersView.tsx
@@ -86,13 +86,22 @@ const PartnersView = ({ partners }: { partners: PartnersViewModel }) => {
                     label={`Comprovantes: ${partner.receiptsStatus === 'enviado' ? 'Enviados' : 'Pendentes'}`}
                     tone={partner.receiptsStatus === 'enviado' ? 'success' : 'warning'}
                   />
-                  <button
-                    onClick={() => partners.onViewDetails(partner)}
-                    className="text-sm font-medium text-blue-600 hover:text-blue-800"
-                    aria-label={`Ver detalhes do parceiro ${partner.name}`}
-                  >
-                    Ver Detalhes
-                  </button>
+                  <div className="flex items-center gap-4">
+                    <button
+                      onClick={() => partners.onEdit(partner)}
+                      className="text-sm font-medium text-gray-700 hover:text-gray-900"
+                      aria-label={`Editar parceiro ${partner.name}`}
+                    >
+                      Editar
+                    </button>
+                    <button
+                      onClick={() => partners.onViewDetails(partner)}
+                      className="text-sm font-medium text-blue-600 hover:text-blue-800"
+                      aria-label={`Ver detalhes do parceiro ${partner.name}`}
+                    >
+                      Ver Detalhes
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Summary
- track the partner currently being edited so the dialog receives pre-filled values and update calls invoke the correct store action
- expose an edit handler in the partners view model and surface an Edit button in the partners list
- adjust supporting tests and mocks to reflect the new editing flow and generic helpers

## Testing
- npm run test -- src/controllers/__tests__/waterDistributionController.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dabcb98c908325a98c602d549f574f