### PR TITLE
feat: allow removing partners

### DIFF
--- a/src/store/useWaterDataStore.ts
+++ b/src/store/useWaterDataStore.ts
@@ -49,6 +49,7 @@ type WaterDataState = {
   deleteCompany: (id: number) => Promise<void>;
   createPartner: (input: PartnerInput) => Promise<Partner>;
   updatePartner: (id: number, input: PartnerInput) => Promise<Partner>;
+  deletePartner: (id: number) => Promise<void>;
   moveKanbanItem: (key: string, nextStage: ReceiptStage) => Promise<KanbanItem>;
 };
 
@@ -337,6 +338,29 @@ export const useWaterDataStore = createStore<WaterDataState>((set, get) => ({
     }));
 
     return partner;
+  },
+  async deletePartner(id) {
+    const existing = get().partners.byId[id];
+    if (!existing) {
+      throw new Error('Parceiro não encontrado.');
+    }
+
+    if (window.api?.partners?.delete) {
+      const response = await window.api.partners.delete(id);
+      if (!response || response.ok !== true) {
+        throw new Error('Não foi possível excluir o parceiro.');
+      }
+    }
+
+    set((current) => {
+      const { [id]: _removed, ...remaining } = current.partners.byId;
+      return {
+        partners: {
+          byId: remaining,
+          allIds: current.partners.allIds.filter((partnerId) => partnerId !== id)
+        }
+      };
+    });
   },
   async moveKanbanItem(key, nextStage) {
     const state = get();

--- a/src/views/__tests__/WaterDistributionViews.test.tsx
+++ b/src/views/__tests__/WaterDistributionViews.test.tsx
@@ -141,9 +141,13 @@ describe('CompaniesView', () => {
 });
 
 describe('PartnersView', () => {
-  it('renders partner cards and triggers details callback', () => {
+  it('renders partner cards and triggers callbacks', () => {
     const onOpenForm = vi.fn();
     const onViewDetails = vi.fn();
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
 
     const viewModel: PartnersViewModel = {
       items: [samplePartner],
@@ -151,13 +155,24 @@ describe('PartnersView', () => {
       isFetching: false,
       error: null,
       onOpenForm,
-      onViewDetails
+      onViewDetails,
+      onEdit,
+      onDelete
     };
 
     render(<PartnersView partners={viewModel} />);
 
     fireEvent.click(screen.getByRole('button', { name: /Ver Detalhes/i }));
     expect(onViewDetails).toHaveBeenCalledWith(samplePartner);
+
+    fireEvent.click(screen.getByRole('button', { name: /Editar parceiro/i }));
+    expect(onEdit).toHaveBeenCalledWith(samplePartner);
+
+    fireEvent.click(screen.getByRole('button', { name: /Excluir parceiro/i }));
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(onDelete).toHaveBeenCalledWith(samplePartner);
+
+    confirmSpy.mockRestore();
     expect(screen.getByText('Distribuidora Norte')).toBeInTheDocument();
   });
 });

--- a/src/views/partners/PartnersView.tsx
+++ b/src/views/partners/PartnersView.tsx
@@ -88,6 +88,19 @@ const PartnersView = ({ partners }: { partners: PartnersViewModel }) => {
                   />
                   <div className="flex items-center gap-4">
                     <button
+                      onClick={() => {
+                        const message = `Tem certeza que deseja excluir o parceiro ${partner.name}?`;
+                        if (typeof window !== 'undefined' && !window.confirm(message)) {
+                          return;
+                        }
+                        partners.onDelete(partner);
+                      }}
+                      className="text-sm font-medium text-red-600 hover:text-red-800"
+                      aria-label={`Excluir parceiro ${partner.name}`}
+                    >
+                      Excluir
+                    </button>
+                    <button
                       onClick={() => partners.onEdit(partner)}
                       className="text-sm font-medium text-gray-700 hover:text-gray-900"
                       aria-label={`Editar parceiro ${partner.name}`}

--- a/tests/e2e/partners.spec.ts
+++ b/tests/e2e/partners.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+const PARTNER_NAME = 'SP Águas Express';
+
+test.describe('Partners management', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Parceiros' }).click();
+    await expect(page.getByRole('heading', { name: 'Parceiros Distribuidores' })).toBeVisible();
+  });
+
+  test('allows deleting a partner after confirmation and shows feedback', async ({ page }) => {
+    page.once('dialog', (dialog) => {
+      expect(dialog.message()).toContain(PARTNER_NAME);
+      dialog.accept();
+    });
+
+    await page.getByRole('button', { name: `Excluir parceiro ${PARTNER_NAME}` }).click();
+
+    await expect(
+      page
+        .getByTestId('toast-message')
+        .filter({ hasText: `Parceiro ${PARTNER_NAME} excluído.` })
+    ).toBeVisible();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: './vitest.setup.ts',
+    exclude: ['node_modules', 'dist', '.git', 'tests/e2e/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html', 'lcov']


### PR DESCRIPTION
## Summary
- add a deletePartner action to the water data store and expose it through the controller
- add partner removal handling with confirmation, UI actions, and toast feedback
- extend automated coverage for partner deletion and exclude Playwright specs from Vitest

## Testing
- npm run test
- npm run test:e2e *(fails: Playwright browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dac4b6db048325a9ca29d97a98f231