### PR TITLE
feat: add kanban totals management dialogs

### DIFF
--- a/src/components/WaterDistributionSystem.tsx
+++ b/src/components/WaterDistributionSystem.tsx
@@ -10,6 +10,8 @@ import KanbanView from '../views/kanban/KanbanView';
 import CompanyDetailsDialog from '../views/companies/CompanyDetailsDialog';
 import PartnerDetailsDialog from '../views/partners/PartnerDetailsDialog';
 import EntityFormDialog from '../views/companies/EntityFormDialog';
+import KanbanEditTotalsDialog from '../views/kanban/KanbanEditTotalsDialog';
+import KanbanHistoryDialog from '../views/kanban/KanbanHistoryDialog';
 import ToastList from '../views/common/ToastList';
 import { useWaterDistributionController } from '../controllers/waterDistributionController';
 
@@ -71,6 +73,8 @@ const WaterDistributionSystem = () => {
       <CompanyDetailsDialog {...controller.dialogs.company} />
       <PartnerDetailsDialog {...controller.dialogs.partner} />
       <EntityFormDialog {...controller.dialogs.form} />
+      <KanbanEditTotalsDialog {...controller.dialogs.kanbanTotals} />
+      <KanbanHistoryDialog {...controller.dialogs.kanbanHistory} />
 
       <ToastList {...controller.toasts} />
     </div>

--- a/src/components/__tests__/WaterDistributionSystem.table.test.tsx
+++ b/src/components/__tests__/WaterDistributionSystem.table.test.tsx
@@ -73,6 +73,7 @@ type StoreState = {
   companies: NormalizedEntities<Company>;
   partners: NormalizedEntities<Partner>;
   kanban: NormalizedKanban;
+  kanbanHistory: Record<string, Array<{ timestamp: string; stage: string; receipts: number; total: number }>>;
   status: { companies: LoadStatus; partners: LoadStatus; kanban: LoadStatus };
   errors: { companies: string | null; partners: string | null; kanban: string | null };
   fetchCompanies: () => Promise<void>;
@@ -85,6 +86,7 @@ type StoreState = {
   updatePartner: () => Promise<Partner>;
   deletePartner: () => Promise<void>;
   moveKanbanItem: () => Promise<KanbanItem>;
+  updateKanbanTotals: () => Promise<KanbanItem>;
 };
 
 function createEmptyEntities<T extends { id: number }>(): NormalizedEntities<T> {
@@ -110,6 +112,7 @@ vi.mock('../../store/useWaterDataStore', () => {
     companies: createEmptyEntities<Company>(),
     partners: createEmptyEntities<Partner>(),
     kanban: createEmptyKanban(),
+    kanbanHistory: {},
     status: { companies: 'success', partners: 'success', kanban: 'success' },
     errors: { companies: null, partners: null, kanban: null },
     fetchCompanies: async () => {},
@@ -133,6 +136,9 @@ vi.mock('../../store/useWaterDataStore', () => {
     },
     moveKanbanItem: async () => {
       throw new Error('moveKanbanItem não mockado');
+    },
+    updateKanbanTotals: async () => {
+      throw new Error('updateKanbanTotals não mockado');
     }
   };
 
@@ -172,11 +178,14 @@ vi.mock('../../store/useWaterDataStore', () => {
     nota_fiscal: state.kanban.byStage.nota_fiscal.map((key) => state.kanban.items[key])
   });
 
+  const selectKanbanHistory = (state: StoreState) => state.kanbanHistory;
+
   return {
     useWaterDataStore,
     selectCompanies,
     selectPartners,
     selectKanbanColumns,
+    selectKanbanHistory,
     __setStoreState: (next: StoreState) => {
       storeState = next;
       listeners.forEach((listener) => listener());
@@ -231,6 +240,7 @@ const createStoreState = (companies: Company[]): StoreState => ({
   companies: normalizeCompanies(companies),
   partners: createEmptyEntities<Partner>(),
   kanban: createEmptyKanban(),
+  kanbanHistory: {},
   status: { companies: 'success', partners: 'success', kanban: 'success' },
   errors: { companies: null, partners: null, kanban: null },
   fetchCompanies: async () => {},
@@ -254,6 +264,9 @@ const createStoreState = (companies: Company[]): StoreState => ({
   },
   moveKanbanItem: async () => {
     throw new Error('moveKanbanItem não mockado');
+  },
+  updateKanbanTotals: async () => {
+    throw new Error('updateKanbanTotals não mockado');
   }
 });
 

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -42,6 +42,13 @@ export type KanbanItem = {
   total: number;
 };
 
+export type KanbanHistoryEntry = {
+  timestamp: string;
+  stage: ReceiptStage;
+  receipts: number;
+  total: number;
+};
+
 export type NormalizedEntities<T extends { id: number }> = {
   byId: Record<number, T>;
   allIds: number[];

--- a/src/views/kanban/KanbanEditTotalsDialog.tsx
+++ b/src/views/kanban/KanbanEditTotalsDialog.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useId, useState } from 'react';
+import OverlayDialog from '../../components/ui/OverlayDialog';
+import { RECEIPT_STAGE_METADATA } from '../../constants/receiptStageMetadata';
+import type { DialogsViewModel } from '../../controllers/waterDistributionController';
+
+const numberInputClasses =
+  'w-full rounded border border-gray-300 px-3 py-2 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200';
+
+const labelClasses = 'block text-sm font-medium text-gray-700';
+
+const errorClasses = 'mt-2 text-sm text-red-600';
+
+type KanbanTotalsDialogProps = DialogsViewModel['kanbanTotals'];
+
+type FormEvent = React.FormEvent<HTMLFormElement>;
+
+type TotalsChangeEvent = React.ChangeEvent<HTMLInputElement>;
+
+type TotalsSubmitValues = { receipts: number; total: number };
+
+const KanbanEditTotalsDialog = ({ isOpen, item, titleId, onClose, onConfirm }: KanbanTotalsDialogProps) => {
+  const [receipts, setReceipts] = useState(0);
+  const [total, setTotal] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const descriptionId = useId();
+
+  useEffect(() => {
+    if (item && isOpen) {
+      setReceipts(item.receipts);
+      setTotal(item.total);
+      setError(null);
+    }
+  }, [item, isOpen]);
+
+  if (!item) {
+    return null;
+  }
+
+  const stageTitle = RECEIPT_STAGE_METADATA[item.stage].title;
+
+  const handleChange = (setter: (value: number) => void) => (event: TotalsChangeEvent) => {
+    const nextValue = Number.parseInt(event.target.value, 10);
+    setter(Number.isNaN(nextValue) ? 0 : nextValue);
+  };
+
+  const validate = (values: TotalsSubmitValues): string | null => {
+    if (values.total <= 0) {
+      return 'O total de comprovantes deve ser maior que zero.';
+    }
+    if (values.receipts < 0) {
+      return 'Os comprovantes processados não podem ser negativos.';
+    }
+    if (values.receipts > values.total) {
+      return 'Os comprovantes processados não podem exceder o total.';
+    }
+    return null;
+  };
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    const values = { receipts, total };
+    const validationError = validate(values);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await onConfirm(values);
+    } catch (submitError) {
+      const message =
+        submitError instanceof Error
+          ? submitError.message
+          : 'Não foi possível atualizar os totais.';
+      setError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <OverlayDialog isOpen={isOpen} onClose={onClose} titleId={titleId} size="md">
+      <form onSubmit={handleSubmit} aria-describedby={descriptionId}>
+        <div className="border-b p-6">
+          <div className="flex items-center justify-between">
+            <h2 id={titleId} className="text-xl font-semibold text-gray-900">
+              Ajustar totais de {item.company}
+            </h2>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded p-2 text-gray-500 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              aria-label="Fechar edição de totais"
+            >
+              ✕
+            </button>
+          </div>
+          <p id={descriptionId} className="mt-2 text-sm text-gray-600">
+            Atualize os comprovantes processados e o total esperado para o estágio "{stageTitle}".
+          </p>
+        </div>
+
+        <div className="space-y-4 p-6">
+          <div>
+            <label htmlFor="receipts" className={labelClasses}>
+              Comprovantes processados
+            </label>
+            <input
+              id="receipts"
+              name="receipts"
+              type="number"
+              inputMode="numeric"
+              min={0}
+              value={receipts}
+              onChange={handleChange(setReceipts)}
+              className={numberInputClasses}
+              aria-describedby="receipts-help"
+            />
+            <p id="receipts-help" className="mt-1 text-xs text-gray-500">
+              Valor atual: {item.receipts}
+            </p>
+          </div>
+
+          <div>
+            <label htmlFor="total" className={labelClasses}>
+              Total de comprovantes
+            </label>
+            <input
+              id="total"
+              name="total"
+              type="number"
+              inputMode="numeric"
+              min={1}
+              value={total}
+              onChange={handleChange(setTotal)}
+              className={numberInputClasses}
+              aria-describedby="total-help"
+            />
+            <p id="total-help" className="mt-1 text-xs text-gray-500">
+              Valor atual: {item.total}
+            </p>
+          </div>
+
+          {error && <p className={errorClasses}>{error}</p>}
+        </div>
+
+        <div className="flex justify-end gap-3 border-t bg-gray-50 p-6">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            Cancelar
+          </button>
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="rounded bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:bg-blue-300"
+          >
+            {isSubmitting ? 'Salvando...' : 'Salvar alterações'}
+          </button>
+        </div>
+      </form>
+    </OverlayDialog>
+  );
+};
+
+export default KanbanEditTotalsDialog;

--- a/src/views/kanban/KanbanHistoryDialog.tsx
+++ b/src/views/kanban/KanbanHistoryDialog.tsx
@@ -1,0 +1,102 @@
+import OverlayDialog from '../../components/ui/OverlayDialog';
+import { RECEIPT_STAGE_METADATA } from '../../constants/receiptStageMetadata';
+import type { DialogsViewModel } from '../../controllers/waterDistributionController';
+
+const historyListClasses = 'divide-y divide-gray-200 rounded-lg border border-gray-200 bg-white';
+
+const historyItemClasses = 'flex flex-col gap-1 p-4 text-sm text-gray-700';
+
+type KanbanHistoryDialogProps = DialogsViewModel['kanbanHistory'];
+
+const formatTimestamp = (timestamp: string): string => {
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return 'Data desconhecida';
+  }
+  return date.toLocaleString('pt-BR', {
+    dateStyle: 'short',
+    timeStyle: 'short'
+  });
+};
+
+const KanbanHistoryDialog = ({ isOpen, item, titleId, onClose, entries }: KanbanHistoryDialogProps) => {
+  if (!item) {
+    return null;
+  }
+
+  const stageMetadata = RECEIPT_STAGE_METADATA[item.stage];
+  const hasEntries = entries.length > 0;
+
+  return (
+    <OverlayDialog isOpen={isOpen} onClose={onClose} titleId={titleId} size="lg">
+      <div className="border-b p-6">
+        <div className="flex items-center justify-between">
+          <h2 id={titleId} className="text-xl font-semibold text-gray-900">
+            Histórico de {item.company}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-2 text-gray-500 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            aria-label="Fechar histórico"
+          >
+            ✕
+          </button>
+        </div>
+        <p className="mt-2 text-sm text-gray-600">
+          Acompanhe as alterações realizadas para o estágio "{stageMetadata.title}".
+        </p>
+      </div>
+
+      <div className="space-y-6 p-6">
+        <div className="rounded-lg bg-gray-50 p-4 text-sm">
+          <p className="font-medium text-gray-700">Resumo atual</p>
+          <div className="mt-2 grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <div>
+              <p className="text-xs uppercase text-gray-500">Estágio</p>
+              <p className="font-medium text-gray-900">{stageMetadata.title}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase text-gray-500">Comprovantes processados</p>
+              <p className="font-medium text-gray-900">{item.receipts}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase text-gray-500">Total de comprovantes</p>
+              <p className="font-medium text-gray-900">{item.total}</p>
+            </div>
+          </div>
+        </div>
+
+        {hasEntries ? (
+          <div>
+            <h3 className="mb-3 text-sm font-semibold text-gray-700">Alterações registradas</h3>
+            <ul className={historyListClasses}>
+              {entries.map((entry, index) => (
+                <li key={`${entry.timestamp}-${index}`} className={historyItemClasses}>
+                  <div className="flex items-center justify-between text-xs text-gray-500">
+                    <span>{formatTimestamp(entry.timestamp)}</span>
+                    <span>{RECEIPT_STAGE_METADATA[entry.stage].title}</span>
+                  </div>
+                  <div className="flex flex-wrap gap-4 text-sm">
+                    <span>
+                      <span className="font-medium text-gray-600">Comprovantes:</span> {entry.receipts}
+                    </span>
+                    <span>
+                      <span className="font-medium text-gray-600">Total:</span> {entry.total}
+                    </span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : (
+          <p className="rounded-lg border border-dashed border-gray-300 p-4 text-sm text-gray-600">
+            Nenhuma alteração registrada até o momento.
+          </p>
+        )}
+      </div>
+    </OverlayDialog>
+  );
+};
+
+export default KanbanHistoryDialog;

--- a/src/views/kanban/__tests__/KanbanDialogs.test.tsx
+++ b/src/views/kanban/__tests__/KanbanDialogs.test.tsx
@@ -1,0 +1,100 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import KanbanEditTotalsDialog from '../KanbanEditTotalsDialog';
+import KanbanHistoryDialog from '../KanbanHistoryDialog';
+import type { DialogsViewModel } from '../../../controllers/waterDistributionController';
+import type { KanbanHistoryEntry, KanbanItem } from '../../../types/entities';
+
+describe('KanbanEditTotalsDialog', () => {
+  const item: KanbanItem = {
+    key: 'Empresa Norte:recebimento',
+    company: 'Empresa Norte',
+    stage: 'recebimento',
+    receipts: 5,
+    total: 10
+  };
+
+  const baseProps: DialogsViewModel['kanbanTotals'] = {
+    isOpen: true,
+    item,
+    titleId: 'editar-totais',
+    onClose: vi.fn(),
+    onConfirm: vi.fn()
+  };
+
+  it('preenche o formulário com os valores atuais e confirma alterações', async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    render(<KanbanEditTotalsDialog {...baseProps} onConfirm={onConfirm} />);
+
+    expect(screen.getByDisplayValue('5')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('10')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/Comprovantes processados/i), { target: { value: '7' } });
+    fireEvent.change(screen.getByLabelText(/Total de comprovantes/i), { target: { value: '12' } });
+    fireEvent.click(screen.getByRole('button', { name: /Salvar alterações/i }));
+
+    expect(onConfirm).toHaveBeenCalledWith({ receipts: 7, total: 12 });
+  });
+
+  it('exibe mensagem de erro quando os comprovantes excedem o total', () => {
+    render(<KanbanEditTotalsDialog {...baseProps} />);
+
+    fireEvent.change(screen.getByLabelText(/Comprovantes processados/i), { target: { value: '11' } });
+    fireEvent.click(screen.getByRole('button', { name: /Salvar alterações/i }));
+
+    expect(
+      screen.getByText('Os comprovantes processados não podem exceder o total.')
+    ).toBeInTheDocument();
+  });
+});
+
+describe('KanbanHistoryDialog', () => {
+  const item: KanbanItem = {
+    key: 'Empresa Sul:relatorio',
+    company: 'Empresa Sul',
+    stage: 'relatorio',
+    receipts: 3,
+    total: 5
+  };
+
+  const entries: KanbanHistoryEntry[] = [
+    {
+      timestamp: new Date('2024-01-01T10:00:00Z').toISOString(),
+      stage: 'relatorio',
+      receipts: 2,
+      total: 5
+    },
+    {
+      timestamp: new Date('2024-02-01T10:00:00Z').toISOString(),
+      stage: 'relatorio',
+      receipts: 3,
+      total: 5
+    }
+  ];
+
+  const baseProps: DialogsViewModel['kanbanHistory'] = {
+    isOpen: true,
+    item,
+    titleId: 'historico-kanban',
+    onClose: vi.fn(),
+    entries: [...entries].sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
+  };
+
+  it('renderiza o resumo atual e as entradas do histórico em ordem', () => {
+    render(<KanbanHistoryDialog {...baseProps} />);
+
+    expect(screen.getByText(/Resumo atual/i)).toBeInTheDocument();
+    const renderedEntries = screen
+      .getAllByText(/Comprovantes:/i)
+      .map((label) => label.parentElement as HTMLElement);
+    expect(renderedEntries).toHaveLength(2);
+    expect(renderedEntries[0]).toHaveTextContent('Comprovantes: 3');
+    expect(renderedEntries[1]).toHaveTextContent('Comprovantes: 2');
+  });
+
+  it('mostra mensagem para histórico vazio', () => {
+    render(<KanbanHistoryDialog {...baseProps} entries={[]} />);
+
+    expect(screen.getByText(/Nenhuma alteração registrada/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add dialogs to edit kanban totals and review history while wiring confirmation callbacks in the controller
- extend the store with kanban history tracking plus a method to persist totals updates used by the new dialogs
- cover the new dialogs and controller flows with dedicated unit tests and refresh existing mocks for the additional selectors

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68dac93b99f8832582a6ea2d0b4c08f3